### PR TITLE
Canvas can return multiple roles over LTI

### DIFF
--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -220,7 +220,8 @@ var setUpModel = function(sequelize) {
     'underscored': true,
     'getterMethods': {
       'is_admin': function() {
-        return _.contains(CollabosphereConstants.ADMIN_ROLES, this.canvas_course_role);
+        var roles = this.canvas_course_role.split(',');
+        return (_.intersection(CollabosphereConstants.ADMIN_ROLES, roles).length !== 0);
       }
     }
   });

--- a/node_modules/col-users/tests/test-users.js
+++ b/node_modules/col-users/tests/test-users.js
@@ -56,18 +56,32 @@ describe('Users', function() {
                 UsersTestUtil.assertGetMe(client, course, null, function(me) {
                   assert.strictEqual(me.is_admin, true);
 
-                  // Verify that other roles are not returned as admins
-                  var nonAdmin1 = TestsUtil.generateUser(null, null, 'Student');
-                  TestsUtil.getAssetLibraryClient(null, null, nonAdmin1, function(client, course, user) {
+                  var admin4 = TestsUtil.generateUser(null, null, 'Instructor,urn:lti:role:ims/lis/TeachingAssistant');
+                  TestsUtil.getAssetLibraryClient(null, null, admin4, function(client, course, user) {
                     UsersTestUtil.assertGetMe(client, course, null, function(me) {
-                      assert.strictEqual(me.is_admin, false);
+                      assert.strictEqual(me.is_admin, true);
 
-                      var nonAdmin2 = TestsUtil.generateUser(null, null, 'FooBar');
-                      TestsUtil.getAssetLibraryClient(null, null, nonAdmin2, function(client, course, user) {
+                      var admin5 = TestsUtil.generateUser(null, null, 'Instructor,FooBar');
+                      TestsUtil.getAssetLibraryClient(null, null, admin5, function(client, course, user) {
                         UsersTestUtil.assertGetMe(client, course, null, function(me) {
-                          assert.strictEqual(me.is_admin, false);
+                          assert.strictEqual(me.is_admin, true);
 
-                          return callback();
+                          // Verify that other roles are not returned as admins
+                          var nonAdmin1 = TestsUtil.generateUser(null, null, 'Student');
+                          TestsUtil.getAssetLibraryClient(null, null, nonAdmin1, function(client, course, user) {
+                            UsersTestUtil.assertGetMe(client, course, null, function(me) {
+                              assert.strictEqual(me.is_admin, false);
+
+                              var nonAdmin2 = TestsUtil.generateUser(null, null, 'FooBar');
+                              TestsUtil.getAssetLibraryClient(null, null, nonAdmin2, function(client, course, user) {
+                                UsersTestUtil.assertGetMe(client, course, null, function(me) {
+                                  assert.strictEqual(me.is_admin, false);
+
+                                  return callback();
+                                });
+                              });
+                            });
+                          });
                         });
                       });
                     });

--- a/node_modules/col-users/tests/util.js
+++ b/node_modules/col-users/tests/util.js
@@ -66,7 +66,8 @@ var assertMe = module.exports.assertMe = function(me, opts) {
   assert.ok(!canvas.lti_secret);
 
   // Ensure that the user is correctly recognised as a (non-)admin
-  if (_.contains(CollabosphereConstants.ADMIN_ROLES, me.canvas_course_role)) {
+  var roles = (me.canvas_course_role || '').split(',');
+  if (_.intersection(CollabosphereConstants.ADMIN_ROLES, roles).length !== 0) {
     assert.strictEqual(me.is_admin, true);
   } else {
     assert.strictEqual(me.is_admin, false);


### PR DESCRIPTION
For example, somehow I ended up as: `Instructor,urn:lti:instrole:ims/lis/Administrator` on my local instance