### PR TITLE
COL-387 Allow whiteboard search and filter - back end

### DIFF
--- a/node_modules/col-assets/tests/test-assets.js
+++ b/node_modules/col-assets/tests/test-assets.js
@@ -658,6 +658,17 @@ describe('Assets', function() {
       AssetsTestUtil.assertGetAssets(client, course, filters, null, null, expectedAssets.length, function(assets) {
         expectedAssets = _.sortBy(expectedAssets, 'id').reverse();
 
+        // The 'total' value should always equal the total count of expected assets
+        assert.strictEqual(assets.total, expectedAssets.length);
+
+        // If there are more than 10 expected assets, only the first 10 should be included in
+        // paged results
+        if (expectedAssets.length < 10) {
+          assert.strictEqual(assets.results.length, expectedAssets.length);
+        } else {
+          assert.strictEqual(assets.results.length, 10);
+        }
+
         _.each(assets.results, function(asset, i) {
           AssetsTestUtil.assertAsset(asset, {'expectedAsset': expectedAssets[i]});
         });

--- a/node_modules/col-rest/lib/rest/whiteboards.js
+++ b/node_modules/col-rest/lib/rest/whiteboards.js
@@ -47,6 +47,9 @@ module.exports = function(client) {
    * Get the whiteboards to which the current user has access in the current course
    *
    * @param  {Course}         course                          The Canvas course in which the user is interacting with the API
+   * @param  {Object}         [filters]                       A set of options to filter the results by
+   * @param  {String}         [filters.keywords]              Keywords matching whiteboard title
+   * @param  {Number}         [filters.user]                  The user id of a whiteboard member
    * @param  {Number}         [limit]                         The maximum number of results to retrieve. Defaults to 10
    * @param  {Number}         [offset]                        The number to start paging from. Defaults to 0
    * @param  {Function}       callback                        Standard callback function
@@ -55,9 +58,12 @@ module.exports = function(client) {
    * @param  {Response}       callback.response               The response object as returned by requestjs
    * @see col-whiteboards/lib/rest.js for more information
    */
-  client.whiteboards.getWhiteboards = function(course, limit, offset, callback) {
+  client.whiteboards.getWhiteboards = function(course, filters, limit, offset, callback) {
+    filters = filters || {};
     var requestUrl = client.util.apiPrefix(course) + '/whiteboards';
     var data = {
+      'keywords': filters.keywords,
+      'user': filters.user,
       'limit': limit,
       'offset': offset
     };

--- a/node_modules/col-whiteboards/lib/api.js
+++ b/node_modules/col-whiteboards/lib/api.js
@@ -210,6 +210,9 @@ var getBasicWhiteboard = function(ctx, id, callback) {
  * Get the whiteboards to which the current user has access in the current course
  *
  * @param  {Context}        ctx                             Standard context containing the current user and the current course
+ * @param  {Object}         [filters]                       A set of options to filter the results by
+ * @param  {String}         [filters.keywords]              Keywords matching whiteboard title
+ * @param  {Number}         [filters.user]                  The user id of a whiteboard member
  * @param  {Number}         [limit]                         The maximum number of results to retrieve. Defaults to 10
  * @param  {Number}         [offset]                        The number to start paging from. Defaults to 0
  * @param  {Function}       callback                        Standard callback function
@@ -219,18 +222,27 @@ var getBasicWhiteboard = function(ctx, id, callback) {
  * @param  {Number}         callback.whiteboards.total      The total number of whiteboards to which the current user has access in the current course
  * @param  {Whiteboard[]}   callback.whiteboards.results    The paged whiteboard to which the current user has access in the current course
  */
-var getWhiteboards = module.exports.getWhiteboards = function(ctx, limit, offset, callback) {
+var getWhiteboards = module.exports.getWhiteboards = function(ctx, filters, limit, offset, callback) {
   // Default some parameters
+  filters = filters || {};
   limit = CollabosphereUtil.getNumberParam(limit, 10, 1, 25);
   offset = CollabosphereUtil.getNumberParam(offset, 0, 0);
 
+  // Ensure the user id is a number
+  filters.user = CollabosphereUtil.getNumberParam(filters.user);
+
   // Parameter validation
   var validationSchema = Joi.object().keys({
+    'filters': Joi.object().keys({
+      'keywords': Joi.string().optional(),
+      'user': Joi.number().optional()
+    }),
     'limit': Joi.number().required(),
     'offset': Joi.number().required()
   });
 
   var validationResult = Joi.validate({
+    'filters': filters,
     'limit': limit,
     'offset': offset
   }, validationSchema);
@@ -240,10 +252,22 @@ var getWhiteboards = module.exports.getWhiteboards = function(ctx, limit, offset
   }
 
   // Get the whiteboards from the DB
-  var options = {
-    'where': {
-      'course_id': ctx.course.id
-    },
+  var where = {
+    '$and': [
+      {'course_id': ctx.course.id}
+    ]
+  };
+  if (filters.keywords) {
+    // Replace spaces with wildcards for basic multi-term matching
+    var keywords = filters.keywords.trim().replace(/ /g, '%');
+    where.$and.push({
+      'title': {
+        '$iLike': '%' + keywords + '%'
+      }
+    });
+  }
+  var queryOptions = {
+    'where': where,
     'include': [
       {
         'model': DB.WhiteboardSession,
@@ -260,20 +284,22 @@ var getWhiteboards = module.exports.getWhiteboards = function(ctx, limit, offset
     'subQuery': false
   };
 
-  // If the current user is not a course administrator, only include the whiteboards
-  // that have been shared with the current user
-  if (!ctx.user.is_admin) {
-    options.include.push({
+  // Filter by user ID if:
+  //  - the current user is not a course administrator and can only view their own boards; or
+  //  - the current user is a course administrator and has applied an optional user filter
+  if (!ctx.user.is_admin || filters.user) {
+    var userId = ctx.user.is_admin ? filters.user : ctx.user.id;
+    queryOptions.include.push({
       'model': DB.User,
       'attributes': ['id'],
       'required': true,
       'where': {
-        'id': ctx.user.id
+        'id': userId
       }
     });
   }
 
-  DB.Whiteboard.findAndCountAll(options).complete(function(err, result) {
+  DB.Whiteboard.findAndCountAll(queryOptions).complete(function(err, result) {
     if (err) {
       log.error({'err': err, 'course': ctx.course, 'user': ctx.user}, 'Failed to get the whiteboards to which the current user has access in the current course');
       return callback({'code': 500, 'msg': err.message});

--- a/node_modules/col-whiteboards/lib/rest.js
+++ b/node_modules/col-whiteboards/lib/rest.js
@@ -53,17 +53,31 @@ Collabosphere.apiRouter.get('/whiteboards/:id', function(req, res) {
  * Get the whiteboards to which the current user has access in the current course
  */
 Collabosphere.apiRouter.get('/whiteboards', function(req, res) {
-  WhiteboardsAPI.getWhiteboards(req.ctx, req.query.limit, req.query.offset, function(err, whiteboards) {
+  var filters = {
+    'keywords': req.query.keywords,
+    'user': req.query.user
+  };
+  WhiteboardsAPI.getWhiteboards(req.ctx, filters, req.query.limit, req.query.offset, function(err, whiteboards) {
     if (err) {
       return res.status(err.code).send(err.msg);
     }
 
+    // Track the whiteboard search
+    if (filters.keywords || filters.user) {
+      AnalyticsAPI.track(req.ctx.user, 'Search whiteboards', {
+        'offset': whiteboards.offset,
+        'total': whiteboards.total,
+        'whiteboards_search_keywords': filters.keywords,
+        'whiteboards_search_user': filters.user
+      });
     // Track the whiteboard listing
-    AnalyticsAPI.track(req.ctx.user, 'List whiteboards', {
-      'offset': whiteboards.offset,
-      'total': whiteboards.total
-    });
-
+    } else {
+      AnalyticsAPI.track(req.ctx.user, 'List whiteboards', {
+        'offset': whiteboards.offset,
+        'total': whiteboards.total
+      });
+    }
+    
     return res.status(200).send(whiteboards);
   });
 });

--- a/node_modules/col-whiteboards/tests/test-whiteboards.js
+++ b/node_modules/col-whiteboards/tests/test-whiteboards.js
@@ -274,41 +274,41 @@ describe('Whiteboards', function() {
       setUpUsers(function(users, course, otherCourse) {
 
         // Retrieve the empty whiteboards list
-        WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, 0, function(whiteboards) {
+        WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, null, 0, function(whiteboards) {
 
           // Create a whiteboard
           WhiteboardsTestUtil.assertCreateWhiteboard(users.creator.client, course, 'UC Berkeley Whiteboard', users.regularA.me.id, function(whiteboard1) {
             // Verify that the whiteboard is returned for the creator
-            WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, 1, function(whiteboards) {
+            WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, null, 1, function(whiteboards) {
               WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedWhiteboard': whiteboard1});
               // Verify that the whiteboard is returned for the other member
-              WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, 1, function(whiteboards) {
+              WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, null, 1, function(whiteboards) {
                 WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedWhiteboard': whiteboard1});
                 // Verify that the whiteboard is not returned for a user that isn't a member
-                WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, 0, function(whiteboards) {
+                WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, null, 0, function(whiteboards) {
                   // Verify that the whiteboard is returned for a course instructor
-                  WhiteboardsTestUtil.assertGetWhiteboards(users.instructor.client, course, null, null, 1, function(whiteboards) {
+                  WhiteboardsTestUtil.assertGetWhiteboards(users.instructor.client, course, null, null, null, 1, function(whiteboards) {
                     WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedWhiteboard': whiteboard1});
 
                     // Create a second whiteboard as a different user
                     WhiteboardsTestUtil.assertCreateWhiteboard(users.regularA.client, course, 'UC Davis Whiteboard', users.regularB.me.id, function(whiteboard2) {
                       // Verify that the first user only has a single whiteboard
-                      WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, 1, function(whiteboards) {
+                      WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, null, 1, function(whiteboards) {
                         WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedWhiteboard': whiteboard1});
                         // Verify that the second user now has 2 whiteboards. The results are expected to return in descending creation date order
-                        WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, 2, function(whiteboards) {
+                        WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, null, 2, function(whiteboards) {
                           WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedWhiteboard': whiteboard2});
                           WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[1], {'expectedWhiteboard': whiteboard1});
                           // Verify that the third user has a single whiteboard
-                          WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, 1, function(whiteboards) {
+                          WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, null, 1, function(whiteboards) {
                             WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedWhiteboard': whiteboard2});
                             // Verify that the course instructor has all whiteboards. The results are expected to return in descending creation date order
-                            WhiteboardsTestUtil.assertGetWhiteboards(users.instructor.client, course, null, null, 2, function(whiteboards) {
+                            WhiteboardsTestUtil.assertGetWhiteboards(users.instructor.client, course, null, null, null, 2, function(whiteboards) {
                               WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedWhiteboard': whiteboard2});
                               WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[1], {'expectedWhiteboard': whiteboard1});
 
                               // Verify that the created whiteboards don't show in a different course
-                              WhiteboardsTestUtil.assertGetWhiteboards(users.instructorOtherCourse.client, otherCourse, null, null, 0, function(whiteboards) {
+                              WhiteboardsTestUtil.assertGetWhiteboards(users.instructorOtherCourse.client, otherCourse, null, null, null, 0, function(whiteboards) {
 
                                 return callback();
                               });
@@ -337,10 +337,10 @@ describe('Whiteboards', function() {
           // First user starts a whiteboard session
           WhiteboardsTestUtil.assertCreateWhiteboardSession(users.regularA.client, course, whiteboard.id, 'socket_id', function() {
             // Second user sees one other user online
-            WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, 1, function(whiteboards) {
+            WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, null, 1, function(whiteboards) {
               WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedOnlineCount': 1});
               // First user sees no other users online
-              WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, 1, function(whiteboards) {
+              WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, null, 1, function(whiteboards) {
                 WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedOnlineCount': 0});
                   
                 return callback();
@@ -370,14 +370,14 @@ describe('Whiteboards', function() {
             whiteboardsB = _.sortBy(whiteboardsB, 'id').reverse();
 
             // Assert that both users can still retrieve their own whiteboards
-            WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, 12, function(pagedWhiteboardsA) {
+            WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, null, 12, function(pagedWhiteboardsA) {
               assert.strictEqual(pagedWhiteboardsA.total, 12);
               assert.strictEqual(pagedWhiteboardsA.results.length, 10);
               _.each(pagedWhiteboardsA.results, function(pagedWhiteboard, index) {
                 WhiteboardsTestUtil.assertWhiteboard(pagedWhiteboard, {'expectedWhiteboard': whiteboardsA[index]});
               });
 
-              WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, 12, function(pagedWhiteboardsB) {
+              WhiteboardsTestUtil.assertGetWhiteboards(users.regularB.client, course, null, null, null, 12, function(pagedWhiteboardsB) {
                 assert.strictEqual(pagedWhiteboardsB.total, 12);
                 assert.strictEqual(pagedWhiteboardsB.results.length, 10);
                 _.each(pagedWhiteboardsB.results, function(pagedWhiteboard, index) {
@@ -403,42 +403,147 @@ describe('Whiteboards', function() {
           whiteboards = _.sortBy(whiteboards, 'id').reverse();
 
           // Verify that the page size defaults to 10 and the page defaults to the first page
-          WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, 12, function(pagedWhiteboards) {
+          WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, null, 12, function(pagedWhiteboards) {
             assert.strictEqual(pagedWhiteboards.results.length, 10);
             _.each(pagedWhiteboards.results, function(pagedWhiteboard, index) {
               WhiteboardsTestUtil.assertWhiteboard(pagedWhiteboard, {'expectedWhiteboard': whiteboards[index]});
             });
 
             // Verify that the second page can be retrieved
-            WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, 10, 12, function(pagedWhiteboards) {
+            WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, null, 10, 12, function(pagedWhiteboards) {
               assert.strictEqual(pagedWhiteboards.results.length, 2);
               _.each(pagedWhiteboards.results, function(pagedWhiteboard, index) {
                 WhiteboardsTestUtil.assertWhiteboard(pagedWhiteboard, {'expectedWhiteboard': whiteboards[10 + index]});
               });
 
               // Verify that a custom page size can be specified
-              WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, 5, null, 12, function(pagedWhiteboards) {
+              WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, 5, null, 12, function(pagedWhiteboards) {
                 assert.strictEqual(pagedWhiteboards.results.length, 5);
                 _.each(pagedWhiteboards.results, function(pagedWhiteboard, index) {
                   WhiteboardsTestUtil.assertWhiteboard(pagedWhiteboard, {'expectedWhiteboard': whiteboards[index]});
                 });
                 // Get the second page using the custom page size
-                WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, 5, 5, 12, function(pagedWhiteboards) {
+                WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, 5, 5, 12, function(pagedWhiteboards) {
                   assert.strictEqual(pagedWhiteboards.results.length, 5);
                   _.each(pagedWhiteboards.results, function(pagedWhiteboard, index) {
                     WhiteboardsTestUtil.assertWhiteboard(pagedWhiteboard, {'expectedWhiteboard': whiteboards[5 + index]});
                   });
                   // Get the last page using the custom page size
-                  WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, 5, 10, 12, function(pagedWhiteboards) {
+                  WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, 5, 10, 12, function(pagedWhiteboards) {
                     assert.strictEqual(pagedWhiteboards.results.length, 2);
                     _.each(pagedWhiteboards.results, function(pagedWhiteboard, index) {
                       WhiteboardsTestUtil.assertWhiteboard(pagedWhiteboard, {'expectedWhiteboard': whiteboards[10 + index]});
                     });
                     // Verify that further pages will be empty
-                    WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, 5, 15, 12, function(pagedWhiteboards) {
+                    WhiteboardsTestUtil.assertGetWhiteboards(users.creator.client, course, null, 5, 15, 12, function(pagedWhiteboards) {
                       assert.strictEqual(pagedWhiteboards.results.length, 0);
 
                       return callback();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  /**
+   * Verify that searching through whiteboards returns the expected whiteboards
+   *
+   * @param  {RestClient}         client                    The REST client to make the request with
+   * @param  {Course}             course                    The Canvas course in which the user is interacting with the API
+   * @param  {Object}             [filters]                 A set of options to filter the results by
+   * @param  {String}             [filters.keywords]        String filter for whiteboard title
+   * @param  {Number}             [filters.user]            The id of a user associated with the whiteboardss
+   * @param  {Whiteboard[]}       expectedWhiteboards       The expected whiteboards
+   * @param  {Function}           callback                  Standard callback function
+   * @throws {AssertionError}                               Error thrown when an assertion failed
+   * @api private
+   */
+  var verifySearch = function(client, course, filters, expectedWhiteboards, callback) {
+    WhiteboardsTestUtil.assertGetWhiteboards(client, course, filters, null, null, expectedWhiteboards.length, function(whiteboards) {
+      expectedWhiteboards = _.sortBy(expectedWhiteboards, 'id').reverse();
+
+      _.each(whiteboards.results, function(whiteboard, i) {
+        WhiteboardsTestUtil.assertWhiteboard(whiteboard, {'expectedWhiteboard': expectedWhiteboards[i]});
+      });
+      return callback();
+    });
+  };
+
+  /**
+   * Test that verifies that whiteboards can be searched through
+   */
+  it('can be searched through', function(callback) {
+    setUpUsers(function(users, course, otherCourse) {
+
+      // Two users generate many inital whiteboards to test paging limit
+      TestsUtil.generateTestWhiteboards(users.regularA.client, course, 12, function(whiteboardsA) {
+        TestsUtil.generateTestWhiteboards(users.regularB.client, course, 12, function(whiteboardsB) {
+
+          // First user creates a private whiteboard
+          WhiteboardsTestUtil.assertCreateWhiteboard(users.regularA.client, course, 'Private Berkeley board', [users.regularA.me.id], function(privateBerkeleyBoard) {
+            whiteboardsA.push(privateBerkeleyBoard);
+
+            // Second user creates a private whiteboard
+            WhiteboardsTestUtil.assertCreateWhiteboard(users.regularB.client, course, 'Private Davis board', [users.regularB.me.id], function(privateDavisBoard) {
+              whiteboardsB.push(privateDavisBoard);
+            
+              // Each user creates one whiteboard shared with the other
+              WhiteboardsTestUtil.assertCreateWhiteboard(users.regularA.client, course, 'Shared Berkeley board', [users.regularA.me.id, users.regularB.me.id], function(sharedBerkeleyBoard) {
+                WhiteboardsTestUtil.assertCreateWhiteboard(users.regularB.client, course, 'Shared Davis board', [users.regularA.me.id, users.regularB.me.id], function(sharedDavisBoard) {
+                  var whiteboardsShared = [sharedBerkeleyBoard, sharedDavisBoard];
+
+                  // When no search filters are specified, a regular user should see all their whiteboards
+                  verifySearch(users.regularA.client, course, null, whiteboardsA.concat(whiteboardsShared), function() {
+                    verifySearch(users.regularB.client, course, null, whiteboardsB.concat(whiteboardsShared), function() {
+
+                      // When keyword filters are applied, a regular user should see only their whiteboards with matching titles
+                      verifySearch(users.regularA.client, course, {'keywords': 'Berkeley'}, [privateBerkeleyBoard, sharedBerkeleyBoard], function() {
+                        verifySearch(users.regularB.client, course, {'keywords': 'Davis'}, [privateDavisBoard, sharedDavisBoard], function() {
+                          verifySearch(users.regularA.client, course, {'keywords': 'Davis'}, [sharedDavisBoard], function() {
+                            verifySearch(users.regularB.client, course, {'keywords': 'Berkeley'}, [sharedBerkeleyBoard], function() {
+
+                              // An administrator should be able to see all whiteboards associated with a user
+                              verifySearch(users.instructor.client, course, {'user': users.regularA.me.id}, whiteboardsA.concat(whiteboardsShared), function() {
+                                verifySearch(users.instructor.client, course, {'user': users.regularB.me.id}, whiteboardsB.concat(whiteboardsShared), function() {
+                                  
+                                  // An administrator should be able to see all whiteboards with titles matching a keyword
+                                  verifySearch(users.instructor.client, course, {'keywords': 'Berkeley'}, [privateBerkeleyBoard, sharedBerkeleyBoard], function() {
+                                    verifySearch(users.instructor.client, course, {'keywords': 'Davis'}, [privateDavisBoard, sharedDavisBoard], function() {
+
+                                      // An administrator should be able to filter by user and keyword both
+                                      verifySearch(users.instructor.client, course, {'user': users.regularA.me.id, 'keywords': 'Berkeley'}, [privateBerkeleyBoard, sharedBerkeleyBoard], function() {
+                                        verifySearch(users.instructor.client, course, {'user': users.regularA.me.id, 'keywords': 'Davis'}, [sharedDavisBoard], function() {
+                                          verifySearch(users.instructor.client, course, {'user': users.regularB.me.id, 'keywords': 'Berkeley'}, [sharedBerkeleyBoard], function() {
+                                            verifySearch(users.instructor.client, course, {'user': users.regularB.me.id, 'keywords': 'Davis'}, [privateDavisBoard, sharedDavisBoard], function() {
+                            
+                                              // Keywords matching nothing should return empty
+                                              verifySearch(users.regularA.client, course, {'keywords': 'This matches nothing'}, [], function() {
+                                                // Keywords matching nothing for a regular user should return empty
+                                                verifySearch(users.regularA.client, course, {'keywords': 'Private Davis'}, [], function() {
+                                                  // Keywords matching nothing within a user filter should return empty
+                                                  verifySearch(users.instructor.client, course, {'user': users.regularA.me.id, 'keywords': 'Private Davis'}, [], function() {
+
+                                                    return callback();
+                                                  });
+                                                });   
+                                              });
+                                            });
+                                          });
+                                        });
+                                      });
+                                    });
+                                  });
+                                });
+                              });
+                            });
+                          });
+                        });
+                      });
                     });
                   });
                 });

--- a/node_modules/col-whiteboards/tests/test-whiteboards.js
+++ b/node_modules/col-whiteboards/tests/test-whiteboards.js
@@ -467,6 +467,17 @@ describe('Whiteboards', function() {
     WhiteboardsTestUtil.assertGetWhiteboards(client, course, filters, null, null, expectedWhiteboards.length, function(whiteboards) {
       expectedWhiteboards = _.sortBy(expectedWhiteboards, 'id').reverse();
 
+      // The 'total' value should always equal the total count of expected whiteboards
+      assert.strictEqual(whiteboards.total, expectedWhiteboards.length);
+
+      // If there are more than 10 expected whiteboards, only the first 10 should be included in
+      // paged results
+      if (expectedWhiteboards.length < 10) {
+        assert.strictEqual(whiteboards.results.length, expectedWhiteboards.length);
+      } else {
+        assert.strictEqual(whiteboards.results.length, 10);
+      }
+
       _.each(whiteboards.results, function(whiteboard, i) {
         WhiteboardsTestUtil.assertWhiteboard(whiteboard, {'expectedWhiteboard': expectedWhiteboards[i]});
       });

--- a/node_modules/col-whiteboards/tests/util.js
+++ b/node_modules/col-whiteboards/tests/util.js
@@ -353,6 +353,9 @@ var assertGetWhiteboardFails = module.exports.assertGetWhiteboardFails = functio
  *
  * @param  {RestClient}         client                          The REST client to make the request with
  * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Object}             [filters]                       A set of options to filter the results by
+ * @param  {String}             [filters.keywords]              String filter for whiteboard title
+ * @param  {Number}             [filters.user]                  The id of a user associated with the whiteboardss
  * @param  {Number}             [limit]                         The maximum number of results to retrieve. Defaults to 10
  * @param  {Number}             [offset]                        The number to start paging from. Defaults to 0
  * @param  {Number}             expectedTotal                   The expected total number of assets in the current course
@@ -363,8 +366,9 @@ var assertGetWhiteboardFails = module.exports.assertGetWhiteboardFails = functio
  * @param  {Whiteboard[]}       callback.whiteboards.results    The paged whiteboard to which the current user has access in the current course
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
-var assertGetWhiteboards = module.exports.assertGetWhiteboards = function(client, course, limit, offset, expectedTotal, callback) {
-  client.whiteboards.getWhiteboards(course, limit, offset, function(err, whiteboards) {
+var assertGetWhiteboards = module.exports.assertGetWhiteboards = function(client, course, filters, limit, offset, expectedTotal, callback) {
+  filters = filters || {};
+  client.whiteboards.getWhiteboards(course, filters, limit, offset, function(err, whiteboards) {
     assert.ok(!err);
     assert.ok(whiteboards);
     assert.ok(_.isNumber(whiteboards.offset));
@@ -377,8 +381,14 @@ var assertGetWhiteboards = module.exports.assertGetWhiteboards = function(client
 
     _.each(whiteboards.results, function(whiteboard) {
       assertWhiteboard(whiteboard);
-    });
 
+      if (filters.keywords) {
+        var keywords = filters.keywords.toLowerCase().split(' ');
+        _.each(keywords, function(keyword) {
+          assert.ok(whiteboard.title.toLowerCase().indexOf(keyword) !== -1);
+        });
+      }
+    });
     return callback(whiteboards);
   });
 };
@@ -388,13 +398,16 @@ var assertGetWhiteboards = module.exports.assertGetWhiteboards = function(client
  *
  * @param  {RestClient}         client                          The REST client to make the request with
  * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Object}             [filters]                       A set of options to filter the results by
+ * @param  {String}             [filters.keywords]              String filter for whiteboard title
+ * @param  {Number}             [filters.user]                  The id of a user associated with the whiteboardss
  * @param  {Number}             [limit]                         The maximum number of results to retrieve. Defaults to 10
  * @param  {Number}             [offset]                        The number to start paging from. Defaults to 0
  * @param  {Number}             code                            The expected HTTP error code
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
-var assertGetWhiteboardsFails = module.exports.assertGetWhiteboardsFails = function(client, course, limit, offset, code, callback) {
+var assertGetWhiteboardsFails = module.exports.assertGetWhiteboardsFails = function(client, course, filters, limit, offset, code, callback) {
   client.whiteboards.getWhiteboards(course, filters, limit, offset, function(err, whiteboards) {
     assert.ok(err);
     assert.strictEqual(err.code, code);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-387 (back end component of https://jira.ets.berkeley.edu/jira/browse/COL-380)

Note the new analytics event 'Search whiteboards', which might require additional integration on the Mixpanel side.