### PR TITLE
COL-401 Collect weekly activity summaries for use in email template

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -41,6 +41,8 @@
   "email": {
     "enabled": true,
     "dailyHour": 8,
+    "weeklyDay": 5,
+    "weeklyHour": 12,
     "apiKey": "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"
   }
 }

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -159,19 +159,19 @@ var handleUser = function(course, activitySummary, user, callback) {
  * @param  {Object}        callback.err                                                         An error object, if any
  * @param  {Object}        callback.courseData                                                  Course data for the weekly email
  * @param  {Object}        callback.courseData.activitySummary                                  Summary of the past week's activity in the course
- * @param  {Object}        callback.courseData.activitySummary.assets                           Assets with activity this week, indexed by id
+ * @param  {Object}        callback.courseData.activitySummary.assets                           Object containing assets with activity this week, keyed by id
  * @param  {Object}        callback.courseData.activitySummary.course                           Course-wide weekly data
  * @param  {Object}        callback.courseData.activitySummary.course.averages                  Course-wide activity and point averages for the week
  * @param  {Object}        callback.courseData.activitySummary.course.topAssets                 Highest-scoring assets for the week
- * @param  {Object}        callback.courseData.activitySummary.course.topAssets.comments        The asset with the most comments for the week
- * @param  {Object}        callback.courseData.activitySummary.course.topAssets.likes           The asset with the most likes for the week
- * @param  {Object}        callback.courseData.activitySummary.course.topAssets.views           The asset with the most views for the week
+ * @param  {Asset}         callback.courseData.activitySummary.course.topAssets.comments        The asset with the most comments for the week
+ * @param  {Asset}         callback.courseData.activitySummary.course.topAssets.likes           The asset with the most likes for the week
+ * @param  {Asset}         callback.courseData.activitySummary.course.topAssets.views           The asset with the most views for the week
  * @param  {Object}        callback.courseData.activitySummary.course.topUsers                  Highest-scoring users for the week
  * @param  {Object}        callback.courseData.activitySummary.course.topUsers.pointsGenerated  The user that generated the most points for the week
  * @param  {Object}        callback.courseData.activitySummary.course.topUsers.pointsReceived   The user that received the most points for the week
  * @param  {CourseTotals}  callback.courseData.activitySummary.course.totals                    Course-wide activity and point totals for the week
- * @param  {Object}        callback.courseData.activitySummary.users                            User activity and point totals, indexed by id
- * @param  {User[]}        callback.data.users                                                  All active users in the course
+ * @param  {Object}        callback.courseData.activitySummary.users                            Object containing user activity and point totals, keyed by id
+ * @param  {Object}        callback.data.users                                                  Object containing all active users in the course, keyed by id
  * @api private
  */
 var getCourseData = function(course, callback) {
@@ -562,7 +562,6 @@ var UserTotals = function() {
  * @param  {Object}    dictionary   Translation dictionary from activity type to property
  * @return {Function}               Activities-incrementing method
  * @api private
- *
  */
 var getActivitiesIncrementer = function(totals, dictionary) {
   /**

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -1,0 +1,583 @@
+/**
+ * Copyright ©2016. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var _ = require('lodash');
+var async = require('async');
+var config = require('config');
+var moment = require('moment-timezone');
+
+var ActivitiesApi = require('col-activities');
+var CollabosphereConstants = require('col-core/lib/constants');
+var CourseAPI = require('col-course');
+var DB = require('col-core/lib/db');
+var EmailUtil = require('col-core/lib/email');
+var log = require('col-core/lib/logger')('col-activities/notifications');
+var UsersAPI = require('col-users');
+var UserConstants = require('col-users/lib/constants');
+
+ /**
+ * Send weekly notification emails for all courses.
+ *
+ * @param  {Function}     callback    Standard callback function
+ */
+var collect = module.exports.collect = function(callback) {
+  var start = Date.now();
+
+  // Get all active courses.
+  CourseAPI.getCourses(function(err, courses) {
+    if (err) {
+      return log.error({'err': err}, 'Unable to retrieve courses for weekly notifications.');
+    }
+
+    // Iterate through all courses.
+    async.eachSeries(courses, collectCourse, function(err) {
+      if (err) {
+        return log.error({'err': err}, 'Unable to collect a course for weekly notifications.');
+      }
+      log.info({'duration': (Date.now() - start)}, 'Sent weekly notifications for all courses.');
+
+      return callback();
+    });
+  });
+};
+
+/**
+ * Send weekly notification emails for a given course.
+ *
+ * Note that this method is only made publicly available so it can be called from the integration
+ * tests. Do not call this method directly.
+ *
+ * @param  {Course}         course          The course for which to send weekly notifications
+ * @param  {Function}       callback        Standard callback function
+ * @api private
+ */
+var collectCourse = module.exports.collectCourse = function(course, callback) {
+  var start = Date.now();
+
+  // 1. Get users and activity data for the course.
+  getCourseData(course, function(err, courseData) {
+    // Don't pass errors up.
+    if (err) {
+      return callback();
+    }
+
+    // Return early if no activity data was found for the course.
+    if (!courseData) {
+      return callback();
+    }
+
+    // 2. Iterate through users in the course and send notifications to each.
+    var userIterator = handleUser.bind(null, course, courseData.activitySummary);
+    async.eachSeries(courseData.users, userIterator, function() {
+      log.info({
+        'course': course.id,
+        'duration': (Date.now() - start)
+      }, 'Sent weekly notifications for course.');
+
+      return callback();
+    });
+  });
+};
+
+/**
+ * Send notifications for a user in a course.
+ *
+ * Note that this function does not pass up errors.
+ *
+ * @param  {Course}     course              The course for which to send notifications
+ * @param  {Object}     activitySummary     Weekly activity data for the course
+ * @param  {User}       user                The user to notify
+ * @param  {Function}   callback            Standard callback function
+ * @api private
+ */
+var handleUser = function(course, activitySummary, user, callback) {
+  // Ignore users without an email address.
+  if (!user.canvas_email) {
+    return callback();
+  }
+
+  // Parse out activity data specific to this user.
+  // TODO: Include ranks for the user: last week's and this week's both.
+
+  var userData = activitySummary.users[user.id] || {};
+  if (!_.isEmpty(userData)) {
+    var topAsset = sampleMaximum(userData.assets, function(asset) {
+      // We define asset 'popularity' as a weighted sum of views, likes and comments.
+      return asset.weeklyTotals.views + (2 * asset.weeklyTotals.likes) + (5 * asset.weeklyTotals.comments);
+    });
+    if (topAsset) {
+      userData.topAsset = userData.assets[topAsset.id];
+    }
+  }
+
+  var subject = 'This week\'s activity in ' + (course.name || 'The Asset Library and Whiteboards');
+  var emailData = {
+    'weekly': {
+      'course': activitySummary.course,
+      'user': userData
+    }
+  };
+
+  EmailUtil.sendEmail(subject, user, course, emailData, 'weekly', function(err) {
+    // Errors are logged in the sendEmail implementation. Ignore them here, and continue to the next user.
+    return callback();
+  });
+};
+
+
+/* Data retrieval */
+
+
+/**
+ * Get activity and user data for a given course in the past week.
+ *
+ * @param  {Context}    course                                 The course for which to get activity data
+ * @param  {Function}   callback                               Standard callback
+ * @param  {Object}     callback.err                           An error object, if any
+ * @param  {Object}     callback.courseData                    Course data for the weekly email
+ * @param  {Object}     callback.courseData.activitySummary    Summary of the past week's activity in the course
+ * @param  {User[]}     callback.data.users                    All active users in the course
+ * @api private
+ */
+var getCourseData = function(course, callback) {
+  var ctx = {
+    'course': course,
+    // Fake an admin user. At this point we can't reliably retrieve an admin from
+    // the database as there might not be any yet
+    'user': {
+      'is_admin': true
+    }
+  };
+
+  // 1. Get all active users in the course.
+  var options = {
+    'enrollmentStates': CollabosphereConstants.ENROLLMENT_STATE.ACTIVE,
+    'includeEmail': true
+  };
+  UsersAPI.getAllUsers(ctx, options, function(err, users) {
+    if (err) {
+      log.error({'err': err, 'course': ctx.course.id}, 'Failed to retrieve the users for a course');
+      return callback(err);
+    }
+
+    // Get user count, then index by id for quick lookup.
+    var userCount = users.length;
+    users = _.chain(users)
+      .map(function(user) {
+        return user.toJSON();
+      })
+      .indexBy('id')
+      .value();
+
+    // 2. Get the points configuration for the course.
+    ActivitiesApi.getActivityTypeConfiguration(ctx.course.id, function(err, activityTypeConfiguration) { 
+      if (err) {
+        log.error({'err': err, 'course': ctx.course.id}, 'Failed to retrieve the points configuration for a course');
+        return callback(err);
+      }
+
+      // 3. Get all activities from the past week. We use a constant time cutoff for the date range so that we're
+      // not affected by processing time during this job.
+      var hour = config.get('email.weeklyHour');
+      var dateRange = {
+        'start': moment()
+          .subtract(7, 'day')
+          .hours(hour).minutes(0).seconds(0)
+          .toDate(),
+        'end': moment()
+          .hours(hour).minutes(0).seconds(0)
+          .toDate()
+      };
+
+      getActivitiesForDateRange(ctx, dateRange, function(err, activities) {
+        if (err) {
+          log.error({'err': err, 'course': ctx.course.id}, 'Failed to retrieve activities for the past week');
+          return callback(err);
+        }
+
+        // Return early if no activities were found.
+        if (_.isEmpty(activities)) {
+          return callback();
+        }
+
+        // 4. Calculate summary data for the week.
+        var activitySummary = summarizeActivities(activities, activityTypeConfiguration, users, userCount);
+        var courseData = {
+          'activitySummary': activitySummary,
+          'users': users
+        };
+
+        return callback(null, courseData);
+      });
+    });
+  });
+};
+
+/**
+ * Get recent activity data for a course.
+ *
+ * @param  {Context}    ctx                  Standard context containing the current user and the current course
+ * @param  {Object}     dateRange            Timestamp range for activity creation
+ * @param  {Date}       dateRange.start      Lower bound for activity creation timestamp
+ * @param  {Date}       dateRange.end        Upper bound for activity creation timestamp
+ * @param  {Function}   callback             Standard callback function
+ * @param  {Object}     callback.err         An error object, if any
+ * @param  {Activity[]} callback.activities  Activity data for the current course within the date range
+ * @api private
+ */
+var getActivitiesForDateRange = function(ctx, dateRange, callback) {
+  var options = {
+    'where': {
+      'course_id': ctx.course.id,
+      'created_at': {'gt': dateRange.start, 'lt': dateRange.end}
+    },
+    'include': [{
+      'model': DB.Asset,
+      'include': [
+        // All we need is the IDs of associated users, but Sequelize forces us to grab some user fields as well.
+        // Get basic fields only.
+        {
+          'model': DB.User, 
+          'as': 'users', 
+          'required': true, 
+          'attributes': UserConstants.BASIC_USER_FIELDS
+        },
+        // Get new comments for this week only, for purposes of counting keywords.
+        {
+          'model': DB.Comment, 
+          'required': true, 
+          'where': {
+            'created_at': {'gt': dateRange.start, 'lt': dateRange.end}
+          }
+        }
+      ]
+    }],
+    'limit': null,
+    'subQuery': false
+  };
+  DB.Activity.findAll(options).complete(function(err, activities) {
+    if (err) {
+      log.error({'err': err, 'course': ctx.course.id}, 'Unable to get recent activities for a course.');
+      return callback(err);
+    }
+    return callback(null, activities);
+  });
+};
+
+
+/* Summary data calculation */
+
+
+/**
+ * Calculate summary data from a list of activities.
+ *
+ * @param  {Activity[]}   activities                   Activities within a date range for a given course
+ * @param  {Object}       activityTypeConfiguration    Activity type configuration for the course
+ * @param  {Object}       users                        All active users in the course indexed by id
+ * @param  {Number}       userCount                    Number of active users in the course
+ * @return {Object}                                    Calculated summary data
+ * @api private
+ */
+var summarizeActivities = function(activities, activityTypeConfiguration, users, userCount) {
+  var courseTotals = new CourseTotals();
+  var summary = {
+    'course': {
+      'totals': courseTotals
+    },
+    'assets': {},
+    'users': {},
+  };
+
+  var activityConfigurationByType = _.indexBy(activityTypeConfiguration, 'type');
+
+  // 1. Increment activities and points in all categories.
+  _.forEach(activities, function(activity) {
+    var type = activity.type;
+    
+    if (activityConfigurationByType[type].enabled) {
+      var assetTotals = getAssetTotals(activity.asset, summary);
+      var userTotals = getUserTotals(activity.user_id, summary);
+
+      // Before assigning points, increment activity counts for the associated user and asset.
+      assetTotals.incrementActivities(type);
+      userTotals.incrementActivities(type);
+
+      // Get the point value. 
+      var points = activityConfigurationByType[type].points;
+
+      // Increment points for the associated user and course under activity type. 
+      userTotals.incrementPoints(type, points);
+      courseTotals.incrementPoints(type, points);
+
+      // Increment points for the associated user and course under generic totals.
+      userTotals.incrementPoints('collected', points);
+      courseTotals.incrementPoints('generated', points);
+
+      if (activity.actor_id && (activity.actor_id !== activity.user_id)) {
+        // The actor and recipient are different users. Count points generated for the actor, and points
+        // received for the recipient and course.
+        var actorTotals = getUserTotals(activity.actor_id, summary);
+        actorTotals.incrementPoints('generated', points);
+        userTotals.incrementPoints('received', points);
+        courseTotals.incrementPoints('received', points);
+      } else {
+        // There is no recipient separate from the actor. Count points generated only.
+        userTotals.incrementPoints('generated', points);
+      }
+    }
+  });
+
+  // 2. Divide course totals by the user count to get averages.
+  summary.course.averages = _.mapValues(summary.course.totals, function(courseTotal) {
+    return _.round(courseTotal / userCount);
+  });
+
+  // 3. Find the top asset in each category.
+  summary.course.topAssets = {};
+  _.forEach(['comments', 'likes', 'views'], function(key) {
+    var topAsset = sampleMaximum(summary.assets, _.property('weeklyTotals.' + key));
+    if (topAsset) {
+      summary.course.topAssets[key] = summary.assets[topAsset.id];
+    }
+  });
+
+  // 4. Find the top user in each category.
+  summary.course.topUsers = {};
+  _.forEach(['pointsGenerated', 'pointsReceived'], function(key) {
+    var topUser = sampleMaximum(summary.users, _.property(key));
+    if (topUser) {
+      summary.course.topUsers[key] = {
+        'total': topUser.value,
+        'user': users[topUser.id]
+      };
+    }
+  });
+
+  // TODO: Iterate through assets to get keyword frequencies from titles and descriptions (if created this
+  // week), and from comments.
+
+  return summary;
+};
+
+/**
+ * Return or instantiate running totals for an asset.
+ * 
+ * @param  {Number}    asset      The asset to get totals for
+ * @param  {Object}    summary    The activities summary
+ * @return {AssetTotals}          Running totals for the given asset
+ * @api private
+ *
+ */
+var getAssetTotals = function(asset, summary) {
+  if (!asset) {
+    return null;
+  }
+  if (!_.has(summary.assets, asset.id)) {
+    // Assets, unlike users, need their full property set stored in the summary as the email template will
+    // make use of them. Add asset properties to the summary, including a new AssetTotals property for the
+    // week.
+    asset = asset.toJSON();
+    asset.weeklyTotals = new AssetTotals();
+    summary.assets[asset.id] = asset;
+
+    // Each asset added to the summary also needs to be accessible from per-user totals, for purposes of.
+    // calculating most popular asset per user.
+    _.each(asset.users, function(assetUser) {
+      var assetUserTotals = getUserTotals(assetUser.id, summary);
+      assetUserTotals.assets[asset.id] = asset;
+    });
+  }
+
+  return summary.assets[asset.id].weeklyTotals;
+};
+
+/**
+ * Return or instantiate running totals for a user.
+ * 
+ * @param  {Number}    userId     The user id to get totals for
+ * @param  {Object}    summary    The activities summary
+ * @return {UserTotals}           Running totals for the given user
+ * @api private
+ *
+ */
+var getUserTotals = function(userId, summary) {
+  if (!_.has(summary.users, userId)) {
+    summary.users[userId] = new UserTotals();
+  }
+  return summary.users[userId];
+};
+
+/**
+ * Running totals for activites and points per asset.
+ */
+var AssetTotals = function() {
+  _.extend(this, {
+    'comments': 0,
+    'likes': 0,
+    'views': 0
+  });
+}
+
+/**
+ * Running totals for activites and points per course.
+ */
+var CourseTotals = function() {
+  _.extend(this, {
+    'pointsFromAssetsUploaded': 0,
+    'pointsFromComments': 0,
+    'pointsFromLikes': 0,
+    'pointsFromWhiteboards': 0,
+    'pointsGenerated': 0,
+    'pointsReceived': 0
+  });
+};
+
+/**
+ * Running totals for activites and points per user.
+ */
+var UserTotals = function() {
+  _.extend(this, {
+    'assets': {},
+    'commentsReceived': 0,
+    'likesReceived': 0,
+    'pointsFromAssetsUploaded': 0,
+    'pointsFromComments': 0,
+    'pointsFromLikes': 0,
+    'pointsFromWhiteboards': 0,
+    'pointsFromCommentsReceived': 0,
+    'pointsFromLikesReceived': 0,
+    'pointsCollected': 0,
+    'pointsGenerated': 0,
+    'pointsReceived': 0
+  });
+};
+
+/**
+ * Given an activity type, find the appropriate running-total property and increment by one.
+ *
+ * @param  {String}    activityType     The activity type to be translated
+ */
+ AssetTotals.prototype.incrementActivities = function(activityType) {
+  // Translate activity type to property name.
+  var property = {
+    'asset_comment': 'comments',
+    'like': 'likes',
+    'view_asset': 'views'
+  }[activityType];
+
+  // Increment the appropriate property if a translation was found.
+  if (_.has(this, property)) {
+    this[property]++;
+  }
+};
+
+/**
+ * Given an activity type, find the appropriate running-total property and increment by one.
+ *
+ * @param  {String}    activityType     The activity type to be translated
+ */
+UserTotals.prototype.incrementActivities = function(activityType) {
+  // Translate activity type to property name.
+  var property = {
+    'get_asset_comment': 'commentsReceived',
+    'get_asset_comment_reply': 'commentsReceived',    
+    'get_like': 'likesReceived'
+  }[activityType];
+
+  // Increment the appropriate property if a translation was found.  
+  if (_.has(this, property)) {
+    this[property]++;
+  }
+};
+
+/**
+ * Given an activity type and points, find the appropriate running-total property and add points.
+ * This method is used both by CourseTotals and by UserTotals.
+ *
+ * @param  {String}    activityType     The activity type to be translated
+ * @param  {Number}    points           The number of points
+ */
+CourseTotals.prototype.incrementPoints = UserTotals.prototype.incrementPoints = function(activityType, points) {
+  var property = {
+    // Properties for activity types stored in the database.
+    'add_asset': 'pointsFromAssetsUploaded',
+    'asset_comment': 'pointsFromComments',
+    'export_whiteboard': 'pointsFromAssetsUploaded',
+    'get_asset_comment': 'pointsFromCommentsReceived',
+    'get_asset_comment_reply': 'pointsFromCommentsReceived',
+    'get_like': 'pointsFromLikesReceived',
+    'like': 'pointsFromLikes',
+    // TODO: These activity types for whiteboards are not yet implemented.
+    'whiteboard_add_asset': 'pointsFromWhiteboards',
+    'whiteboard_chat': 'pointsFromWhiteboards',
+    // Generic activity types used for summary totals.
+    'collected': 'pointsCollected',
+    'generated': 'pointsGenerated',
+    'received': 'pointsReceived'
+  }[activityType];
+
+  // Increment the appropriate property by the given number of points if a translation was found.  
+  if (_.has(this, property)) {
+    this[property] += points;
+  }
+};
+
+
+/* Utilities */
+
+
+/**
+ * Iterate over an object, subjecting each element to a transformation, and return the maximum transformed 
+ * value and one associated key (choosing the key at random in the case of a tie). If no transformation 
+ * yields a positive number, return null.
+ *
+ * @param  {Object}    object           The object to be iterated
+ * @param  {Function}  transformation   The transformation to be applied
+ * @return {Object}                     The maximum transformed value and one associated key
+ * @api private
+ */
+var sampleMaximum = function(object, transformation) {
+  var ids = null;
+  var maximumValue = 0;
+  _.forEach(object, function(value, key) {
+    var transformedValue = transformation(value);
+    if (transformedValue >= maximumValue) {
+      if (transformedValue > maximumValue) {
+        ids = [];
+        maximumValue = transformedValue;
+      }
+      if (ids) {
+        ids.push(key);
+      }
+    }
+  });
+  if (!ids) {
+    return null;
+  }
+  return {
+    'id': _.sample(ids),
+    'value': maximumValue
+  }
+};

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -28,7 +28,6 @@ var async = require('async');
 var config = require('config');
 var moment = require('moment-timezone');
 
-var ActivitiesApi = require('col-activities');
 var CollabosphereConstants = require('col-core/lib/constants');
 var CourseAPI = require('col-course');
 var DB = require('col-core/lib/db');
@@ -37,7 +36,9 @@ var log = require('col-core/lib/logger')('col-activities/notifications');
 var UsersAPI = require('col-users');
 var UserConstants = require('col-users/lib/constants');
 
- /**
+var ActivitiesAPI = require('col-activities');
+
+/**
  * Send weekly notification emails for all courses.
  *
  * @param  {Function}     callback    Standard callback function
@@ -48,16 +49,13 @@ var collect = module.exports.collect = function(callback) {
   // Get all active courses.
   CourseAPI.getCourses(function(err, courses) {
     if (err) {
-      return log.error({'err': err}, 'Unable to retrieve courses for weekly notifications.');
+      log.error({'err': err}, 'Unable to retrieve courses for weekly notifications.');
+      return callback();
     }
 
     // Iterate through all courses.
-    async.eachSeries(courses, collectCourse, function(err) {
-      if (err) {
-        return log.error({'err': err}, 'Unable to collect a course for weekly notifications.');
-      }
+    async.eachSeries(courses, collectCourse, function() {
       log.info({'duration': (Date.now() - start)}, 'Sent weekly notifications for all courses.');
-
       return callback();
     });
   });
@@ -78,13 +76,15 @@ var collectCourse = module.exports.collectCourse = function(course, callback) {
 
   // 1. Get users and activity data for the course.
   getCourseData(course, function(err, courseData) {
-    // Don't pass errors up.
+    // If a course throws an error, log it and continue to the next course.
     if (err) {
+      log.error({'course': course.id, 'err': err}, 'Unable to collect course data for weekly notification email.');
       return callback();
     }
 
     // Return early if no activity data was found for the course.
     if (!courseData) {
+      log.info({'course': course.id}, 'No course data found for weekly notification email.');
       return callback();
     }
 
@@ -123,8 +123,9 @@ var handleUser = function(course, activitySummary, user, callback) {
 
   var userData = activitySummary.users[user.id] || {};
   if (!_.isEmpty(userData)) {
+    // Find the user's most popular asset for the last week. We define asset 'popularity' as a weighted 
+    // sum of views, likes and comments.
     var topAsset = sampleMaximum(userData.assets, function(asset) {
-      // We define asset 'popularity' as a weighted sum of views, likes and comments.
       return asset.weeklyTotals.views + (2 * asset.weeklyTotals.likes) + (5 * asset.weeklyTotals.comments);
     });
     if (topAsset) {
@@ -153,12 +154,19 @@ var handleUser = function(course, activitySummary, user, callback) {
 /**
  * Get activity and user data for a given course in the past week.
  *
- * @param  {Context}    course                                 The course for which to get activity data
- * @param  {Function}   callback                               Standard callback
- * @param  {Object}     callback.err                           An error object, if any
- * @param  {Object}     callback.courseData                    Course data for the weekly email
- * @param  {Object}     callback.courseData.activitySummary    Summary of the past week's activity in the course
- * @param  {User[]}     callback.data.users                    All active users in the course
+ * @param  {Context}       course                                                The course for which to get activity data
+ * @param  {Function}      callback                                              Standard callback
+ * @param  {Object}        callback.err                                          An error object, if any
+ * @param  {Object}        callback.courseData                                   Course data for the weekly email
+ * @param  {Object}        callback.courseData.activitySummary                   Summary of the past week's activity in the course
+ * @param  {Object}        callback.courseData.activitySummary.assets            Assets with activity this week, indexed by id
+ * @param  {Object}        callback.courseData.activitySummary.course            Course-wide weekly data
+ * @param  {Object}        callback.courseData.activitySummary.course.averages   Course-wide activity and point averages for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topAssets  Highest-scoring assets for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topUsers   Highest-scoring users for the week
+ * @param  {CourseTotals}  callback.courseData.activitySummary.course.totals     Course-wide activity and point totals for the week
+ * @param  {Object}        callback.courseData.activitySummary.users             User activity and point totals, indexed by id
+ * @param  {User[]}        callback.data.users                                   All active users in the course
  * @api private
  */
 var getCourseData = function(course, callback) {
@@ -182,8 +190,7 @@ var getCourseData = function(course, callback) {
       return callback(err);
     }
 
-    // Get user count, then index by id for quick lookup.
-    var userCount = users.length;
+    // Index users by id for quick lookup.
     users = _.chain(users)
       .map(function(user) {
         return user.toJSON();
@@ -192,7 +199,7 @@ var getCourseData = function(course, callback) {
       .value();
 
     // 2. Get the points configuration for the course.
-    ActivitiesApi.getActivityTypeConfiguration(ctx.course.id, function(err, activityTypeConfiguration) { 
+    ActivitiesAPI.getActivityTypeConfiguration(ctx.course.id, function(err, activityTypeConfiguration) { 
       if (err) {
         log.error({'err': err, 'course': ctx.course.id}, 'Failed to retrieve the points configuration for a course');
         return callback(err);
@@ -223,7 +230,7 @@ var getCourseData = function(course, callback) {
         }
 
         // 4. Calculate summary data for the week.
-        var activitySummary = summarizeActivities(activities, activityTypeConfiguration, users, userCount);
+        var activitySummary = summarizeActivities(activities, activityTypeConfiguration, users);
         var courseData = {
           'activitySummary': activitySummary,
           'users': users
@@ -267,7 +274,7 @@ var getActivitiesForDateRange = function(ctx, dateRange, callback) {
         // Get new comments for this week only, for purposes of counting keywords.
         {
           'model': DB.Comment, 
-          'required': true, 
+          'required': false, 
           'where': {
             'created_at': {'gt': dateRange.start, 'lt': dateRange.end}
           }
@@ -296,11 +303,10 @@ var getActivitiesForDateRange = function(ctx, dateRange, callback) {
  * @param  {Activity[]}   activities                   Activities within a date range for a given course
  * @param  {Object}       activityTypeConfiguration    Activity type configuration for the course
  * @param  {Object}       users                        All active users in the course indexed by id
- * @param  {Number}       userCount                    Number of active users in the course
  * @return {Object}                                    Calculated summary data
  * @api private
  */
-var summarizeActivities = function(activities, activityTypeConfiguration, users, userCount) {
+var summarizeActivities = function(activities, activityTypeConfiguration, users) {
   var courseTotals = new CourseTotals();
   var summary = {
     'course': {
@@ -350,6 +356,7 @@ var summarizeActivities = function(activities, activityTypeConfiguration, users,
   });
 
   // 2. Divide course totals by the user count to get averages.
+  var userCount = _.keys(users).length;
   summary.course.averages = _.mapValues(summary.course.totals, function(courseTotal) {
     return _.round(courseTotal / userCount);
   });
@@ -384,9 +391,13 @@ var summarizeActivities = function(activities, activityTypeConfiguration, users,
 /**
  * Return or instantiate running totals for an asset.
  * 
- * @param  {Number}    asset      The asset to get totals for
- * @param  {Object}    summary    The activities summary
- * @return {AssetTotals}          Running totals for the given asset
+ * @param  {Number}        asset                  The asset to get totals for
+ * @param  {Object}        summary                The weekly activities summary
+ * @param  {Object}        summary.assets         Assets with activity this week, indexed by id
+ * @param  {Object}        summary.course         Course-wide weekly data
+ * @param  {CourseTotals}  summary.course.totals  Course-wide activity and point totals for the week
+ * @param  {Object}        summary.users          User activity and point totals, indexed by id
+ * @return {AssetTotals}                          Running totals for the given asset
  * @api private
  *
  */
@@ -394,7 +405,7 @@ var getAssetTotals = function(asset, summary) {
   if (!asset) {
     return null;
   }
-  if (!_.has(summary.assets, asset.id)) {
+  if (!summary.assets[asset.id]) {
     // Assets, unlike users, need their full property set stored in the summary as the email template will
     // make use of them. Add asset properties to the summary, including a new AssetTotals property for the
     // week.
@@ -402,7 +413,7 @@ var getAssetTotals = function(asset, summary) {
     asset.weeklyTotals = new AssetTotals();
     summary.assets[asset.id] = asset;
 
-    // Each asset added to the summary also needs to be accessible from per-user totals, for purposes of.
+    // Each asset added to the summary also needs to be accessible from per-user totals, for purposes of
     // calculating most popular asset per user.
     _.each(asset.users, function(assetUser) {
       var assetUserTotals = getUserTotals(assetUser.id, summary);
@@ -416,9 +427,12 @@ var getAssetTotals = function(asset, summary) {
 /**
  * Return or instantiate running totals for a user.
  * 
- * @param  {Number}    userId     The user id to get totals for
- * @param  {Object}    summary    The activities summary
- * @return {UserTotals}           Running totals for the given user
+ * @param  {Number}        userId                 The user id to get totals for
+ * @param  {Object}        summary                The activities summary
+ * @param  {Object}        summary.course         Course-wide weekly data
+ * @param  {CourseTotals}  summary.course.totals  Course-wide activity and point totals for the week
+ * @param  {Object}        summary.users          User activity and point totals, indexed by id
+ * @return {UserTotals}                           Running totals for the given user
  * @api private
  *
  */
@@ -433,32 +447,59 @@ var getUserTotals = function(userId, summary) {
  * Running totals for activites and points per asset.
  */
 var AssetTotals = function() {
-  _.extend(this, {
+  var that = {
     'comments': 0,
     'likes': 0,
     'views': 0
-  });
-}
+  };
+
+  /**
+   * Given an activity type, find the appropriate running-total property and increment by one.
+   *
+   * @param  {String}    activityType     The activity type to be translated
+   */
+  that.incrementActivities = function(activityType) {
+    // Translate activity type to property name.
+    var dictionary = {
+       'asset_comment': 'comments',
+       'like': 'likes',
+       'view_asset': 'views'
+    };
+    var property = dictionary[activityType];
+
+    // Increment the appropriate property if a translation was found.
+    if (_.has(that, property)) {
+      that[property]++;
+    }
+  };
+
+  return that;
+};
 
 /**
  * Running totals for activites and points per course.
  */
 var CourseTotals = function() {
-  _.extend(this, {
+  var that = {
     'pointsFromAssetsUploaded': 0,
     'pointsFromComments': 0,
     'pointsFromLikes': 0,
     'pointsFromWhiteboards': 0,
     'pointsGenerated': 0,
     'pointsReceived': 0
-  });
+  };
+
+  // Define a method to increment point totals.
+  that.incrementPoints = getPointsIncrementer(that);
+
+  return that;
 };
 
 /**
  * Running totals for activites and points per user.
  */
 var UserTotals = function() {
-  _.extend(this, {
+  var that = {
     'assets': {},
     'commentsReceived': 0,
     'likesReceived': 0,
@@ -471,77 +512,75 @@ var UserTotals = function() {
     'pointsCollected': 0,
     'pointsGenerated': 0,
     'pointsReceived': 0
-  });
+  };
+
+  /**
+   * Given an activity type, find the appropriate running-total property and increment by one.
+   *
+   * @param  {String}    activityType     The activity type to be translated
+   */
+  that.incrementActivities = function(activityType) {
+    // Translate activity type to property name.
+    var dictionary = {
+      'get_asset_comment': 'commentsReceived',
+      'get_asset_comment_reply': 'commentsReceived',
+      'get_like': 'likesReceived'
+    };
+    var property = dictionary[activityType];
+
+    // Increment the appropriate property if a translation was found.
+    if (_.has(that, property)) {
+      that[property]++;
+    }
+  };
+
+  // Define a method to increment point totals.
+  that.incrementPoints = getPointsIncrementer(that);
+
+  return that;
 };
 
 /**
- * Given an activity type, find the appropriate running-total property and increment by one.
+ * Define a method to increment points on a running-totals object.
  *
- * @param  {String}    activityType     The activity type to be translated
- */
- AssetTotals.prototype.incrementActivities = function(activityType) {
-  // Translate activity type to property name.
-  var property = {
-    'asset_comment': 'comments',
-    'like': 'likes',
-    'view_asset': 'views'
-  }[activityType];
-
-  // Increment the appropriate property if a translation was found.
-  if (_.has(this, property)) {
-    this[property]++;
-  }
-};
-
-/**
- * Given an activity type, find the appropriate running-total property and increment by one.
+ * @param  {Object}    totals    The running-totals object on which to increment points
+ * @return {Function}            Points-incrementing method
+ * @api private
  *
- * @param  {String}    activityType     The activity type to be translated
  */
-UserTotals.prototype.incrementActivities = function(activityType) {
-  // Translate activity type to property name.
-  var property = {
-    'get_asset_comment': 'commentsReceived',
-    'get_asset_comment_reply': 'commentsReceived',    
-    'get_like': 'likesReceived'
-  }[activityType];
+var getPointsIncrementer = function(totals) {
+  /**
+   * Given an activity type and points, find the appropriate running-total property and add points.
+   *
+   * @param  {String}    activityType     The activity type to be translated
+   * @param  {Number}    points           The number of points
+   */
+  return function(activityType, points) {
+    // Translate activity type to property name.
+    var dictionary = {
+      // Properties for activity types stored in the database.
+      'add_asset': 'pointsFromAssetsUploaded',
+      'asset_comment': 'pointsFromComments',
+      'export_whiteboard': 'pointsFromAssetsUploaded',
+      'get_asset_comment': 'pointsFromCommentsReceived',
+      'get_asset_comment_reply': 'pointsFromCommentsReceived',
+      'get_like': 'pointsFromLikesReceived',
+      'like': 'pointsFromLikes',
+      // TODO: These activity types for whiteboards are not yet implemented.
+      'whiteboard_add_asset': 'pointsFromWhiteboards',
+      'whiteboard_chat': 'pointsFromWhiteboards',
+      // Generic activity types used for summary totals.
+      'collected': 'pointsCollected',
+      'generated': 'pointsGenerated',
+      'received': 'pointsReceived'
+    };
+    var property = dictionary[activityType];
 
-  // Increment the appropriate property if a translation was found.  
-  if (_.has(this, property)) {
-    this[property]++;
-  }
-};
-
-/**
- * Given an activity type and points, find the appropriate running-total property and add points.
- * This method is used both by CourseTotals and by UserTotals.
- *
- * @param  {String}    activityType     The activity type to be translated
- * @param  {Number}    points           The number of points
- */
-CourseTotals.prototype.incrementPoints = UserTotals.prototype.incrementPoints = function(activityType, points) {
-  var property = {
-    // Properties for activity types stored in the database.
-    'add_asset': 'pointsFromAssetsUploaded',
-    'asset_comment': 'pointsFromComments',
-    'export_whiteboard': 'pointsFromAssetsUploaded',
-    'get_asset_comment': 'pointsFromCommentsReceived',
-    'get_asset_comment_reply': 'pointsFromCommentsReceived',
-    'get_like': 'pointsFromLikesReceived',
-    'like': 'pointsFromLikes',
-    // TODO: These activity types for whiteboards are not yet implemented.
-    'whiteboard_add_asset': 'pointsFromWhiteboards',
-    'whiteboard_chat': 'pointsFromWhiteboards',
-    // Generic activity types used for summary totals.
-    'collected': 'pointsCollected',
-    'generated': 'pointsGenerated',
-    'received': 'pointsReceived'
-  }[activityType];
-
-  // Increment the appropriate property by the given number of points if a translation was found.  
-  if (_.has(this, property)) {
-    this[property] += points;
-  }
+    // Increment the appropriate property by the given number of points if a translation was found.
+    if (_.has(totals, property)) {
+      totals[property] += points;
+    }
+  };
 };
 
 
@@ -559,7 +598,7 @@ CourseTotals.prototype.incrementPoints = UserTotals.prototype.incrementPoints = 
  * @api private
  */
 var sampleMaximum = function(object, transformation) {
-  var ids = null;
+  var ids = [];
   var maximumValue = 0;
   _.forEach(object, function(value, key) {
     var transformedValue = transformation(value);
@@ -568,12 +607,12 @@ var sampleMaximum = function(object, transformation) {
         ids = [];
         maximumValue = transformedValue;
       }
-      if (ids) {
+      if (maximumValue > 0) {
         ids.push(key);
       }
     }
   });
-  if (!ids) {
+  if (!ids.length) {
     return null;
   }
   return {

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -78,13 +78,13 @@ var collectCourse = module.exports.collectCourse = function(course, callback) {
   getCourseData(course, function(err, courseData) {
     // If a course throws an error, log it and continue to the next course.
     if (err) {
-      log.error({'course': course.id, 'err': err}, 'Unable to collect course data for weekly notification email.');
+      log.error({'course': course, 'err': err}, 'Unable to collect course data for weekly notification email.');
       return callback();
     }
 
     // Return early if no activity data was found for the course.
     if (!courseData) {
-      log.info({'course': course.id}, 'No course data found for weekly notification email.');
+      log.info({'course': course}, 'No course data found for weekly notification email.');
       return callback();
     }
 
@@ -154,19 +154,24 @@ var handleUser = function(course, activitySummary, user, callback) {
 /**
  * Get activity and user data for a given course in the past week.
  *
- * @param  {Context}       course                                                The course for which to get activity data
- * @param  {Function}      callback                                              Standard callback
- * @param  {Object}        callback.err                                          An error object, if any
- * @param  {Object}        callback.courseData                                   Course data for the weekly email
- * @param  {Object}        callback.courseData.activitySummary                   Summary of the past week's activity in the course
- * @param  {Object}        callback.courseData.activitySummary.assets            Assets with activity this week, indexed by id
- * @param  {Object}        callback.courseData.activitySummary.course            Course-wide weekly data
- * @param  {Object}        callback.courseData.activitySummary.course.averages   Course-wide activity and point averages for the week
- * @param  {Object}        callback.courseData.activitySummary.course.topAssets  Highest-scoring assets for the week
- * @param  {Object}        callback.courseData.activitySummary.course.topUsers   Highest-scoring users for the week
- * @param  {CourseTotals}  callback.courseData.activitySummary.course.totals     Course-wide activity and point totals for the week
- * @param  {Object}        callback.courseData.activitySummary.users             User activity and point totals, indexed by id
- * @param  {User[]}        callback.data.users                                   All active users in the course
+ * @param  {Context}       course                                                               The course for which to get activity data
+ * @param  {Function}      callback                                                             Standard callback
+ * @param  {Object}        callback.err                                                         An error object, if any
+ * @param  {Object}        callback.courseData                                                  Course data for the weekly email
+ * @param  {Object}        callback.courseData.activitySummary                                  Summary of the past week's activity in the course
+ * @param  {Object}        callback.courseData.activitySummary.assets                           Assets with activity this week, indexed by id
+ * @param  {Object}        callback.courseData.activitySummary.course                           Course-wide weekly data
+ * @param  {Object}        callback.courseData.activitySummary.course.averages                  Course-wide activity and point averages for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topAssets                 Highest-scoring assets for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topAssets.comments        The asset with the most comments for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topAssets.likes           The asset with the most likes for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topAssets.views           The asset with the most views for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topUsers                  Highest-scoring users for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topUsers.pointsGenerated  The user that generated the most points for the week
+ * @param  {Object}        callback.courseData.activitySummary.course.topUsers.pointsReceived   The user that received the most points for the week
+ * @param  {CourseTotals}  callback.courseData.activitySummary.course.totals                    Course-wide activity and point totals for the week
+ * @param  {Object}        callback.courseData.activitySummary.users                            User activity and point totals, indexed by id
+ * @param  {User[]}        callback.data.users                                                  All active users in the course
  * @api private
  */
 var getCourseData = function(course, callback) {
@@ -444,7 +449,7 @@ var getUserTotals = function(userId, summary) {
 };
 
 /**
- * Running totals for activites and points per asset.
+ * Running totals for activities per asset.
  */
 var AssetTotals = function() {
   var that = {
@@ -453,31 +458,20 @@ var AssetTotals = function() {
     'views': 0
   };
 
-  /**
-   * Given an activity type, find the appropriate running-total property and increment by one.
-   *
-   * @param  {String}    activityType     The activity type to be translated
-   */
-  that.incrementActivities = function(activityType) {
-    // Translate activity type to property name.
-    var dictionary = {
-       'asset_comment': 'comments',
-       'like': 'likes',
-       'view_asset': 'views'
-    };
-    var property = dictionary[activityType];
-
-    // Increment the appropriate property if a translation was found.
-    if (_.has(that, property)) {
-      that[property]++;
-    }
+  // Define a method to increment activity counts.
+  var activitiesDictionary = {
+    'asset_comment': 'comments',
+    'like': 'likes',
+    'view_asset': 'views'
   };
+
+  that.incrementActivities = getActivitiesIncrementer(that, activitiesDictionary);
 
   return that;
 };
 
 /**
- * Running totals for activites and points per course.
+ * Running totals for points per course.
  */
 var CourseTotals = function() {
   var that = {
@@ -490,13 +484,27 @@ var CourseTotals = function() {
   };
 
   // Define a method to increment point totals.
-  that.incrementPoints = getPointsIncrementer(that);
+  var pointsDictionary = {
+    // Properties for activity types stored in the database.
+    'add_asset': 'pointsFromAssetsUploaded',
+    'asset_comment': 'pointsFromComments',
+    'export_whiteboard': 'pointsFromAssetsUploaded',
+    'like': 'pointsFromLikes',
+    // TODO: These activity types for whiteboards are not yet implemented.
+    'whiteboard_add_asset': 'pointsFromWhiteboards',
+    'whiteboard_chat': 'pointsFromWhiteboards',
+    // Generic activity types used for summary totals.
+    'generated': 'pointsGenerated',
+    'received': 'pointsReceived'
+  };
+
+  that.incrementPoints = getPointsIncrementer(that, pointsDictionary);
 
   return that;
 };
 
 /**
- * Running totals for activites and points per user.
+ * Running totals for activities and points per user.
  */
 var UserTotals = function() {
   var that = {
@@ -514,41 +522,75 @@ var UserTotals = function() {
     'pointsReceived': 0
   };
 
-  /**
-   * Given an activity type, find the appropriate running-total property and increment by one.
-   *
-   * @param  {String}    activityType     The activity type to be translated
-   */
-  that.incrementActivities = function(activityType) {
-    // Translate activity type to property name.
-    var dictionary = {
-      'get_asset_comment': 'commentsReceived',
-      'get_asset_comment_reply': 'commentsReceived',
-      'get_like': 'likesReceived'
-    };
-    var property = dictionary[activityType];
-
-    // Increment the appropriate property if a translation was found.
-    if (_.has(that, property)) {
-      that[property]++;
-    }
+  // Define a method to increment activity counts.
+  var activitiesDictionary = {
+    'get_asset_comment': 'commentsReceived',
+    'get_asset_comment_reply': 'commentsReceived',
+    'get_like': 'likesReceived'
   };
 
+  that.incrementActivities = getActivitiesIncrementer(that, activitiesDictionary);
+
   // Define a method to increment point totals.
-  that.incrementPoints = getPointsIncrementer(that);
+  var pointsDictionary = {
+    // Properties for activity types stored in the database.
+    'add_asset': 'pointsFromAssetsUploaded',
+    'asset_comment': 'pointsFromComments',
+    'export_whiteboard': 'pointsFromAssetsUploaded',
+    'get_asset_comment': 'pointsFromCommentsReceived',
+    'get_asset_comment_reply': 'pointsFromCommentsReceived',
+    'get_like': 'pointsFromLikesReceived',
+    'like': 'pointsFromLikes',
+    // TODO: These activity types for whiteboards are not yet implemented.
+    'whiteboard_add_asset': 'pointsFromWhiteboards',
+    'whiteboard_chat': 'pointsFromWhiteboards',
+    // Generic activity types used for summary totals.
+    'collected': 'pointsCollected',
+    'generated': 'pointsGenerated',
+    'received': 'pointsReceived'
+  };
+
+  that.incrementPoints = getPointsIncrementer(that, pointsDictionary);
 
   return that;
 };
 
 /**
- * Define a method to increment points on a running-totals object.
+ * Define a method to increment activity counts on a running-totals object.
  *
- * @param  {Object}    totals    The running-totals object on which to increment points
- * @return {Function}            Points-incrementing method
+ * @param  {Object}    totals       The running-totals object on which to increment activity counts
+ * @param  {Object}    dictionary   Translation dictionary from activity type to property
+ * @return {Function}               Activities-incrementing method
  * @api private
  *
  */
-var getPointsIncrementer = function(totals) {
+var getActivitiesIncrementer = function(totals, dictionary) {
+  /**
+   * Given an activity type, find the appropriate running-total property and increment by one.
+   *
+   * @param  {String}    activityType     The activity type to be translated
+   */
+  return function(activityType) {
+    // Translate activity type to property name.
+    var property = dictionary[activityType];
+
+    // Increment the appropriate property if a translation was found.
+    if (_.has(totals, property)) {
+      totals[property]++;
+    }
+  };
+};
+
+/**
+ * Define a method to increment points on a running-totals object.
+ *
+ * @param  {Object}    totals       The running-totals object on which to increment points
+ * @param  {Object}    dictionary   Translation dictionary from activity type to property
+ * @return {Function}               Points-incrementing method
+ * @api private
+ *
+ */
+var getPointsIncrementer = function(totals, dictionary) {
   /**
    * Given an activity type and points, find the appropriate running-total property and add points.
    *
@@ -557,23 +599,6 @@ var getPointsIncrementer = function(totals) {
    */
   return function(activityType, points) {
     // Translate activity type to property name.
-    var dictionary = {
-      // Properties for activity types stored in the database.
-      'add_asset': 'pointsFromAssetsUploaded',
-      'asset_comment': 'pointsFromComments',
-      'export_whiteboard': 'pointsFromAssetsUploaded',
-      'get_asset_comment': 'pointsFromCommentsReceived',
-      'get_asset_comment_reply': 'pointsFromCommentsReceived',
-      'get_like': 'pointsFromLikesReceived',
-      'like': 'pointsFromLikes',
-      // TODO: These activity types for whiteboards are not yet implemented.
-      'whiteboard_add_asset': 'pointsFromWhiteboards',
-      'whiteboard_chat': 'pointsFromWhiteboards',
-      // Generic activity types used for summary totals.
-      'collected': 'pointsCollected',
-      'generated': 'pointsGenerated',
-      'received': 'pointsReceived'
-    };
     var property = dictionary[activityType];
 
     // Increment the appropriate property by the given number of points if a translation was found.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-401

Notes:
- This code has been exercised locally in the console, but there are no tests yet. Integration tests will follow once data is hooked up to the email template.
- Two not-yet-implemented activity types are assumed: `whiteboard_add_asset` and `whiteboard_chat`.
- Keyword counts for the week are to be added in a later task.
- User leaderboard ranks, present and past, are to be added in a later task.
- For now, weekly email scheduling is arbitrarily configured to Friday at noon. This configuration is used in setting the date range for the activities query, but is not yet added to the scheduling code in `col-activities/lib/notifications/api.js`.