### PR TITLE
COL-413 Script for Node REPL with preloaded Collabosphere environment

### DIFF
--- a/scripts/col-repl.js
+++ b/scripts/col-repl.js
@@ -24,6 +24,8 @@
  */
 
 var _ = require('lodash');
+var repl = require('repl');
+
 var DB = require('col-core/lib/db');
 
 /**
@@ -40,9 +42,8 @@ var init = function() {
 
     // Require additional modules and utilities, assigning them to properties 
     // to be exported to the REPL.
-
     var exports = {
-      // External modules
+      // A small set of external modules ; more could be added.
       'async': require('async'),
       'config': require('config'),
       'Joi': require('joi'),
@@ -52,7 +53,9 @@ var init = function() {
       'moment': require('moment-timezone'),
       'Sequelize': require('sequelize'),
 
-      // Collabosphere modules
+      // Collabosphere modules, including:
+      // - Top-level APIs;
+      // - 
       'ActivitiesAPI': require('col-activities'),
       'ActivitiesDefaults': require('col-activities/lib/default'),
       'AnalyticsAPI': require('col-analytics'),
@@ -67,6 +70,8 @@ var init = function() {
       'DB': DB,
       'EmailUtil': require('col-core/lib/email'),
       'log': require('col-core/lib/logger')('col-repl'),
+      'LtiAPI': require('col-lti'),
+      'LtiConstants': require('col-lti/lib/constants'),
       'RestAPI': require('col-rest'),
       'UserConstants': require('col-users/lib/constants'),
       'UsersAPI': require('col-users')
@@ -75,9 +80,8 @@ var init = function() {
     console.log('Collabosphere environment loaded. Enjoy!');
 
     // Start the REPL and make exports available.
-
-    var repl = require('repl').start({prompt: 'col-repl> '});
-    _.extend(repl.context, exports);
+    var replInstance = repl.start({'prompt': 'col-repl> '});
+    _.extend(replInstance.context, exports);
   });
 };
 

--- a/scripts/col-repl.js
+++ b/scripts/col-repl.js
@@ -28,11 +28,12 @@ var repl = require('repl');
 
 var DB = require('col-core/lib/db');
 
-/**
- * Load Collabosphere environment and start REPL
- */
 console.log('Loading Collabosphere environment...');
 
+/**
+ * Load Collabosphere environment and start an instance of Node's REPL (read-eval-print loop), 
+ an interactive interpreter that evaluates input line by line and displays evaluation results.
+ */
 var init = function() {
   // Apply global utilities
   require('col-core/lib/globals');
@@ -43,7 +44,7 @@ var init = function() {
     // Require additional modules and utilities, assigning them to properties 
     // to be exported to the REPL.
     var exports = {
-      // A small set of external modules ; more could be added.
+      // A small set of external modules frequently used in code; more could be added.
       'async': require('async'),
       'config': require('config'),
       'Joi': require('joi'),
@@ -55,7 +56,7 @@ var init = function() {
 
       // Collabosphere modules, including:
       // - Top-level APIs;
-      // - 
+      // - Constants and utilities frequently called across modules.
       'ActivitiesAPI': require('col-activities'),
       'ActivitiesDefaults': require('col-activities/lib/default'),
       'AnalyticsAPI': require('col-analytics'),
@@ -75,6 +76,7 @@ var init = function() {
       'RestAPI': require('col-rest'),
       'UserConstants': require('col-users/lib/constants'),
       'UsersAPI': require('col-users')
+      // WhiteboardAPI is not included as it expects a running Express server on load.
     };
 
     console.log('Collabosphere environment loaded. Enjoy!');

--- a/scripts/col-repl.js
+++ b/scripts/col-repl.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright ©2016. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var _ = require('lodash');
+var DB = require('col-core/lib/db');
+
+/**
+ * Load Collabosphere environment and start REPL
+ */
+console.log('Loading Collabosphere environment...');
+
+var init = function() {
+  // Apply global utilities
+  require('col-core/lib/globals');
+    
+  // Connect to the Collabosphere database
+  DB.init(function() {
+
+    // Require additional modules and utilities, assigning them to properties 
+    // to be exported to the REPL.
+
+    var exports = {
+      // External modules
+      'async': require('async'),
+      'config': require('config'),
+      'Joi': require('joi'),
+      // Node's REPL treats _ as a special variable, returning the result of the last 
+      // expression, so we can't assign to it.
+      'lodash': _,
+      'moment': require('moment-timezone'),
+      'Sequelize': require('sequelize'),
+
+      // Collabosphere modules
+      'ActivitiesAPI': require('col-activities'),
+      'ActivitiesDefaults': require('col-activities/lib/default'),
+      'AnalyticsAPI': require('col-analytics'),
+      'AssetsAPI': require('col-assets'),
+      'CanvasAPI': require('col-canvas'),
+      'CategoriesAPI': require('col-categories'),
+      'Collabosphere': require('col-core'),
+      'CollabosphereConstants': require('col-core/lib/constants'),
+      'CollabosphereUtil': require('col-core/lib/util'),
+      'CourseAPI': require('col-course'),
+      'DailyNotifications': require('col-activities/lib/notifications/daily'),
+      'DB': DB,
+      'EmailUtil': require('col-core/lib/email'),
+      'log': require('col-core/lib/logger')('col-repl'),
+      'RestAPI': require('col-rest'),
+      'UserConstants': require('col-users/lib/constants'),
+      'UsersAPI': require('col-users')
+    };
+
+    console.log('Collabosphere environment loaded. Enjoy!');
+
+    // Start the REPL and make exports available.
+
+    var repl = require('repl').start({prompt: 'col-repl> '});
+    _.extend(repl.context, exports);
+  });
+};
+
+init();

--- a/scripts/col-repl.js
+++ b/scripts/col-repl.js
@@ -32,7 +32,8 @@ console.log('Loading Collabosphere environment...');
 
 /**
  * Load Collabosphere environment and start an instance of Node's REPL (read-eval-print loop), 
- an interactive interpreter that evaluates input line by line and displays evaluation results.
+ * an interactive interpreter that evaluates input line by line and displays evaluation results.
+ * @see https://nodejs.org/api/repl.html
  */
 var init = function() {
   // Apply global utilities


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-413

I've found this handy enough during local development that I decided to submit it. Rails devs will recognize it as a sketchy gesture toward a Rails console-like environment.

Example usage:

```
 % node scripts/col-repl
Loading Collabosphere environment...
[2016-07-21T19:29:48.883Z]  INFO: col-core/email/43411 on MacBook-Pro-2.local: No image manifest found in the document root. Using development assets (documentRoot=/var/www/html)
[2016-07-21T19:29:48.900Z]  INFO: col-activities/43411 on MacBook-Pro-2.local: Scheduling daily notifications for 2016-07-22T08:00:00-07:00 (in 70211998 ms)
Collabosphere environment loaded. Enjoy!
col-repl> CourseAPI.getCourses(function(err, courses) { log.info(courses[0].dataValues); });
undefined
[2016-07-21T19:29:59.723Z]  INFO: Intermediate Hittite/43411 on MacBook-Pro-2.local:  (id=285, canvas_course_id=1, enable_upload=true, assetlibrary_url=http://localhost:3100/courses/1/external_tools/4, whiteboards_url=http://localhost:3100/courses/1/external_tools/5, active=true, created_at=2016-05-23T20:25:34.170Z, updated_at=2016-05-23T20:26:37.183Z, canvas_api_domain=localhost:3100)
    
    --
    canvas: {
      "canvas_api_domain": "localhost:3100",
      "use_https": false,
      "name": "Localhost",
      "logo": "none",
      "created_at": "2016-05-16T23:17:55.076Z",
      "updated_at": "2016-05-16T23:17:55.076Z"
    }

col-repl> ActivitiesAPI.getActivities({course: {id: 285}}, null, null, null, function(err, activities) { log.info(activities.length + ' activities found'); });
undefined
[2016-07-21T19:30:16.058Z]  INFO: col-repl/43411 on MacBook-Pro-2.local: 33 activities found
col-repl> 
```