### PR TITLE
COL-400 Calculate current user ranks for weekly email

### DIFF
--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -119,8 +119,6 @@ var handleUser = function(course, activitySummary, user, callback) {
   }
 
   // Parse out activity data specific to this user.
-  // TODO: Include ranks for the user: last week's and this week's both.
-
   var userData = activitySummary.users[user.id] || {};
   if (!_.isEmpty(userData)) {
     // Find the user's most popular asset for the last week. We define asset 'popularity' as a weighted 
@@ -184,24 +182,37 @@ var getCourseData = function(course, callback) {
     }
   };
 
-  // 1. Get all active users in the course.
+  // 1. Get all active users in the course and their total points.
   var options = {
     'enrollmentStates': CollabosphereConstants.ENROLLMENT_STATE.ACTIVE,
     'includeEmail': true
   };
-  UsersAPI.getAllUsers(ctx, options, function(err, users) {
+  UsersAPI.getLeaderboard(ctx, options, function(err, users) {
     if (err) {
       log.error({'err': err, 'course': ctx.course.id}, 'Failed to retrieve the users for a course');
       return callback(err);
     }
 
-    // Index users by id for quick lookup.
-    users = _.chain(users)
-      .map(function(user) {
-        return user.toJSON();
-      })
-      .indexBy('id')
-      .value();
+    // Calculate user ranks. Users are returned in descending order of score, so rank can be derived from array index. Rank 
+    // is defined as the number of users with a higher score, plus one; e.g., scores [200, 100, 50, 50, 25] map to ranks
+    // [1, 2, 3, 3, 5].
+    // TODO: Store this week's ranks and retrieve last week's ranks.
+    var pointsCutoff = null;
+    var rank = 1;
+    users = _.map(users, function(user, index) {
+      if (user.points !== pointsCutoff) {
+        rank = index + 1;
+        pointsCutoff = user.points;
+      }
+      return _.extend(user.toJSON(), {
+        'rank': {
+          'thisWeek': rank
+        }
+      });
+    });
+
+    // Index users by id for quick lookup.  
+    users = _.indexBy(users, 'id');
 
     // 2. Get the points configuration for the course.
     ActivitiesAPI.getActivityTypeConfiguration(ctx.course.id, function(err, activityTypeConfiguration) { 

--- a/node_modules/col-users/lib/api.js
+++ b/node_modules/col-users/lib/api.js
@@ -272,7 +272,7 @@ var getUsers = module.exports.getUsers = function(ctx, ids, callback) {
  * @param  {Context}    ctx                             Standard context containing the current user and the current course
  * @param  {Object}     [options]                       Filter options
  * @param  {String[]}   [options.enrollmentStates]      The enrollment states of the users in the course. One of {@link CollabosphereConstants.ENROLLMENT_STATE}. Defaults to `active` and `invited`
- * @param  {String}     [options.includeEmail]          Whether to include the email address on the user objects. It's up to the caller to ensure email addresses are dealt with securely
+ * @param  {String}     [options.includeEmail]          Whether to include the email address on the user objects. Defaults to false. It's up to the caller to ensure email addresses are dealt with securely
  * @param  {Function}   callback                        Standard callback function
  * @param  {Object}     callback.err                    An error that occurred, if any
  * @param  {User[]}     callback.users                  All users in the current course
@@ -286,7 +286,7 @@ var getAllUsers = module.exports.getAllUsers = function(ctx, options, callback) 
 
   var attributes = UserConstants.BASIC_USER_FIELDS;
   if (options.includeEmail) {
-    attributes = _.union(UserConstants.BASIC_USER_FIELDS, ['canvas_email']);
+    attributes = _.union(UserConstants.BASIC_USER_FIELDS, UserConstants.EMAIL_FIELDS);
   }
 
   // Get the users from the DB
@@ -314,7 +314,7 @@ var getAllUsers = module.exports.getAllUsers = function(ctx, options, callback) 
  * @param  {Context}    ctx                             Standard context containing the current user and the current course
  * @param  {Object}     [options]                       Filter options
  * @param  {String[]}   [options.enrollmentStates]      The enrollment states of the users in the course. One of {@link CollabosphereConstants.ENROLLMENT_STATE}. Defaults to `active` and `invited`
- * @param  {String}     [options.includeEmail]          Whether to include the email address on the user objects. It's up to the caller to ensure email addresses are dealt with securely
+ * @param  {String}     [options.includeEmail]          Whether to include the email address on the user objects. Defaults to false. It's up to the caller to ensure email addresses are dealt with securely
  * @param  {Function}   callback                        Standard callback function
  * @param  {Object}     callback.err                    An error that occurred, if any
  * @param  {User[]}     callback.users                  The users in the current course and their points
@@ -328,7 +328,7 @@ var getLeaderboard = module.exports.getLeaderboard = function(ctx, options, call
 
   var attributes = UserConstants.POINTS_USER_FIELDS;
   if (options.includeEmail) {
-    attributes = _.union(UserConstants.POINTS_USER_FIELDS, ['canvas_email']);
+    attributes = _.union(UserConstants.POINTS_USER_FIELDS, UserConstants.EMAIL_FIELDS);
   }
 
   // Only instructors and users that have opted into sharing their points with

--- a/node_modules/col-users/lib/api.js
+++ b/node_modules/col-users/lib/api.js
@@ -312,11 +312,25 @@ var getAllUsers = module.exports.getAllUsers = function(ctx, options, callback) 
  * Get the users in the current course and their points
  *
  * @param  {Context}    ctx                             Standard context containing the current user and the current course
+ * @param  {Object}     [options]                       Filter options
+ * @param  {String[]}   [options.enrollmentStates]      The enrollment states of the users in the course. One of {@link CollabosphereConstants.ENROLLMENT_STATE}. Defaults to `active` and `invited`
+ * @param  {String}     [options.includeEmail]          Whether to include the email address on the user objects. It's up to the caller to ensure email addresses are dealt with securely
  * @param  {Function}   callback                        Standard callback function
  * @param  {Object}     callback.err                    An error that occurred, if any
  * @param  {User[]}     callback.users                  The users in the current course and their points
  */
-var getLeaderboard = module.exports.getLeaderboard = function(ctx, callback) {
+var getLeaderboard = module.exports.getLeaderboard = function(ctx, options, callback) {
+  options = options || {};
+  options.enrollmentStates = options.enrollmentStates || [
+    CollabosphereConstants.ENROLLMENT_STATE.ACTIVE,
+    CollabosphereConstants.ENROLLMENT_STATE.INVITED
+  ];
+
+  var attributes = UserConstants.POINTS_USER_FIELDS;
+  if (options.includeEmail) {
+    attributes = _.union(UserConstants.POINTS_USER_FIELDS, ['canvas_email']);
+  }
+
   // Only instructors and users that have opted into sharing their points with
   // the course are able to retrieve the list of users for the course
   if (!ctx.user.share_points && !ctx.user.is_admin) {
@@ -325,22 +339,22 @@ var getLeaderboard = module.exports.getLeaderboard = function(ctx, callback) {
   }
 
   // Get the users from the DB
-  var options = {
+  var queryOptions = {
     'where': {
       'course_id': ctx.course.id,
-      'canvas_enrollment_state': ['active', 'invited']
+      'canvas_enrollment_state': options.enrollmentStates
     },
-    'attributes': UserConstants.POINTS_USER_FIELDS,
+    'attributes': attributes,
     'order': 'points DESC, id ASC'
   };
 
   // Only instructors are able to see all users in the course. Non-administrators
   // are only able to see the users that have opted into sharing their points with the course
   if (!ctx.user.is_admin) {
-    options.where.share_points = true;
+    queryOptions.where.share_points = true;
   }
 
-  DB.User.findAll(options).complete(function(err, users) {
+  DB.User.findAll(queryOptions).complete(function(err, users) {
     if (err) {
       log.error({'err': err, 'course': ctx.course}, 'Failed to get the users in the current course');
       return callback({'code': 500, 'msg': err.message});

--- a/node_modules/col-users/lib/constants.js
+++ b/node_modules/col-users/lib/constants.js
@@ -25,5 +25,6 @@
 
 var Constants = module.exports = {
   'BASIC_USER_FIELDS': ['id', 'canvas_user_id', 'canvas_course_role', 'canvas_enrollment_state', 'canvas_full_name', 'canvas_image'],
+  'EMAIL_FIELDS': ['canvas_email'],
   'POINTS_USER_FIELDS': ['id', 'canvas_user_id', 'canvas_course_role', 'canvas_enrollment_state', 'canvas_full_name', 'canvas_image', 'points', 'share_points', 'last_activity']
 };

--- a/node_modules/col-users/lib/rest.js
+++ b/node_modules/col-users/lib/rest.js
@@ -57,7 +57,7 @@ Collabosphere.apiRouter.get('/users', function(req, res) {
  * Get the users in the current course and their points
  */
 Collabosphere.apiRouter.get('/users/leaderboard', function(req, res) {
-  UsersAPI.getLeaderboard(req.ctx, function(err, users) {
+  UsersAPI.getLeaderboard(req.ctx, null, function(err, users) {
     if (err) {
       return res.status(err.code).send(err.msg);
     }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-400

Since we need both points and email addresses for users, the function signature of UsersAPI.getLeaderboard is expanded to include an `options` object, following the pattern of UsersAPI.getAllUsers. These changes are opaque to our current integration test suite, but will need to be covered in integration tests for the weekly email.

The various permutations for rank calculation will also need test coverage.