### PR TITLE
COL-383, set process.exitCode instead of calling process.exit() directly

### DIFF
--- a/node_modules/col-whiteboards/data/whiteboardToPng.js
+++ b/node_modules/col-whiteboards/data/whiteboardToPng.js
@@ -27,6 +27,7 @@
 
 var _ = require('lodash');
 var fabric = require('fabric').fabric;
+var log = require('col-core/lib/logger')('col-whiteboards/data/whiteboardToPng');
 
 // The amount of padding (in pixels) that should be added to whiteboards that get exported to PNG
 var WHITEBOARD_PADDING = 10;
@@ -38,20 +39,27 @@ var WHITEBOARD_PADDING = 10;
  */
 var init = function() {
   // Get the whiteboard elements from standard in
-  getWhiteboardElements(function(whiteboardElements) {
+  getWhiteboardElements(function(err, whiteboardElements) {
 
-    // Create a PNG stream for these elements
-    generatePng(whiteboardElements, function(err, data, dimensions) {
-      if (err) {
-        console.error(err);
-        process.exit(2);
-      }
-
-      // Write the PNG data out over standard out and exit the process
-      process.stdout.write(data);
-      process.stdout.write(JSON.stringify(dimensions));
-      process.exit(0);
-    });
+    if (err) {
+      log.error({'err': err}, 'Failed to load whiteboard elements.');
+      process.exitCode = 1;
+    } else {
+      // Create a PNG stream for these elements
+      generatePng(whiteboardElements, function(err, data, dimensions) {
+        // Rather than calling process.exit() directly, set the process.exitCode and allow the process to exit naturally
+        // @see https://nodejs.org/api/process.html
+        if (err) {
+          log.error({'err': err}, 'Unable to generate PNG file.');
+          process.exitCode = 2;
+        } else {
+          // Write the PNG data out over standard out and exit the process
+          process.stdout.write(data);
+          process.stdout.write(JSON.stringify(dimensions));
+          process.exitCode = 0;
+        }
+      });
+    }
   });
 };
 
@@ -80,12 +88,11 @@ var getWhiteboardElements = function(callback) {
       try {
         whiteboardElements = JSON.parse(data.split('\n')[0]);
       } catch (err) {
-        console.error(err);
-        console.error('Could not parse the input JSON');
-        process.exit(1);
+        log.error({'err': err}, 'Could not parse the input JSON');
+        return callback(err);
       };
 
-      return callback(whiteboardElements);
+      return callback(null, whiteboardElements);
     }
   });
 };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-383

See https://nodejs.org/api/process.html regarding misuse of `process.exit()`.  I want to be sure we're not losing info that would be otherwise be written to stdout. See best practice described in URL above. Excerpt:
```
It is important to note that calling process.exit() will force the process to exit 
as quickly as possible even if there are still asynchronous operations pending 
that have not yet completed fully, including I/O operations to process.stdout 
and process.stderr.
```
