### PR TITLE
COL-425 Allow course admins to manually trigger weekly email from the browser

### DIFF
--- a/config/travis.js
+++ b/config/travis.js
@@ -46,6 +46,8 @@ module.exports = {
   },
   "email": {
     "enabled": false,
-    "dailyHour": ((new Date().getHours() + 2) % 34)
+    // We set these values two hours in the future so that the integration tests will pick up just-created activities. 
+    "dailyHour": ((new Date().getHours() + 2) % 34),
+    "weeklyHour": ((new Date().getHours() + 2) % 34)
   }
 }

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -62,16 +62,31 @@ var collect = module.exports.collect = function(callback) {
 };
 
 /**
- * Send weekly notification emails for a given course.
+ * Manually trigger weekly notification emails for a given course. This method is made publicly available for testing and 
+ * administrative purposes only; it should not be used for regular scheduling of emails.
  *
- * Note that this method is only made publicly available so it can be called from the integration
- * tests. Do not call this method directly.
+ * @param  {Context}          ctx                               Standard context containing the current user and the current course
+ * @param  {Function}         callback                          Standard callback function
+ * @param  {Object}           callback.err                      An error that occurred, if any
+ */
+var sendWeeklyNotificationsForCourse = module.exports.sendWeeklyNotificationsForCourse = function(ctx, callback) {
+  // Only admins can manually trigger the weekly email.
+  if (!ctx.user.is_admin) {
+    log.error({'id': ctx.user.id, 'course': ctx.course.id}, 'Unauthorized to send weekly notifications for course');
+    return callback({'code': 401, 'msg': 'Unauthorized to send weekly notifications for a course'});
+  }
+
+  return collectCourse(ctx.course, callback);
+};
+
+/**
+ * Send weekly notification emails for a given course.
  *
  * @param  {Course}         course          The course for which to send weekly notifications
  * @param  {Function}       callback        Standard callback function
  * @api private
  */
-var collectCourse = module.exports.collectCourse = function(course, callback) {
+var collectCourse = function(course, callback) {
   var start = Date.now();
 
   // 1. Get users and activity data for the course.

--- a/node_modules/col-activities/lib/rest.js
+++ b/node_modules/col-activities/lib/rest.js
@@ -31,6 +31,7 @@ var Collabosphere = require('col-core');
 var CollabosphereUtil = require('col-core/lib/util');
 
 var ActivitiesAPI = require('./api');
+var WeeklyNotifications = require('./notifications/weekly');
 
 /*!
  * Export the activities for a course as a CSV file
@@ -82,5 +83,19 @@ Collabosphere.apiRouter.post('/activities/configuration', function(req, res) {
     }
 
     return res.sendStatus(200);
+  });
+});
+
+/*!
+ * Manually trigger the weekly email notification for a course. We use a GET request since this is an admin-only
+ * endpoint entered into the browser. 
+ */
+Collabosphere.apiRouter.get('/activities/notifications/send_weekly', function(req, res) {
+  WeeklyNotifications.sendWeeklyNotificationsForCourse(req.ctx, function(err) {
+    if (err) {
+      return res.status(err.code).send(err.msg);
+    }
+
+    return res.status(200).send({'sending': true});
   });
 });

--- a/node_modules/col-activities/tests/test-daily.js
+++ b/node_modules/col-activities/tests/test-daily.js
@@ -26,11 +26,9 @@
 var _ = require('lodash');
 var assert = require('assert');
 var moment = require('moment-timezone');
-var randomstring = require('randomstring');
 
 var AssetsTestUtil = require('col-assets/tests/util');
 var DB = require('col-core/lib/db');
-var LtiTestUtil = require('col-lti/tests/util');
 var TestsUtil = require('col-tests');
 var UsersTestUtil = require('col-users/tests/util');
 var WhiteboardsTestUtil = require('col-whiteboards/tests/util');
@@ -43,7 +41,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that emails are only sent to those users who need to be notified
    */
   it('sends emails to only those users who need to be notified', function(callback) {
-    setupCourse(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourse(function(dbCourse, course, users) {
 
       // Verify that no emails are sent out in a course that has no activities
       ActivitiesTestUtil.assertDailyNotifications(dbCourse, [], function(emails) {
@@ -107,7 +105,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that the email subject depends on which activities took place
    */
   it('changes the email subject depending on which activities took place', function(callback) {
-    setupCourseWithActivity(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
 
       // Oliver ends up with 2 asset activities
       AssetsTestUtil.assertCreateLink(users.oliver.client, course, 'title', 'http://www.google.com', null, function(asset2) {
@@ -152,7 +150,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that replies on an asset owner's comment are grouped as replies
    */
   it('groups replies on an asset owner\'s comment correctly', function(callback) {
-    setupCourse(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourse(function(dbCourse, course, users) {
 
       // Simon creates a comment on his own comment which Nico then comments on
       AssetsTestUtil.assertCreateComment(users.simon.client, course, users.simon.asset.id, 'This is a comment', null, function(topComment) {
@@ -188,7 +186,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that the correct greetings are present
    */
   it('creates the correct greetings', function(callback) {
-    setupCourse(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourse(function(dbCourse, course, users) {
 
       // If only 1 activity block is present in the email, there's no need for the greeting
       AssetsTestUtil.assertCreateComment(users.simon.client, course, users.nico.asset.id, 'This is a comment', null, function() {
@@ -280,7 +278,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that emails contain absolute links to the asset library and whiteboard
    */
   it('should contain absolute links to the asset library and whiteboard tool', function(callback) {
-    setupCourseWithActivity(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
 
       // Collect the daily notifications
       var expectedEmailedUsers = [users.nico.me, users.annesophie.me, users.simon.me, users.paul.me];
@@ -320,7 +318,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that aggregation is performed on the asset or whiteboard
    */
   it('aggregates on asset or whiteboard', function(callback) {
-    setupCourse(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourse(function(dbCourse, course, users) {
 
       // Oliver comments on all assets and each asset owner replies in return. Everyone should get
       // an email with a single activity, except for Oliver who should have 4 activities
@@ -361,7 +359,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that the amount of comments per activity is limited
    */
   it('the amount of comments per activity is limited', function(callback) {
-    setupCourse(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourse(function(dbCourse, course, users) {
       // Create a comment with 3 replies
       AssetsTestUtil.assertCreateComment(users.nico.client, course, users.nico.asset.id, 'This is a comment', null, function(parent) {
         AssetsTestUtil.assertCreateComment(users.simon.client, course, users.nico.asset.id, 'This is reply 1', parent.id, function(reply1) {
@@ -416,7 +414,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that the amount of chat messages per activity is limited
    */
   it('the amount of chat messages per activity is limited', function(callback) {
-    setupCourse(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourse(function(dbCourse, course, users) {
       // Create a 4 chat messages
       WhiteboardsTestUtil.assertEditWhiteboard(users.simon.client, course, users.simon.whiteboard.id, users.simon.whiteboard.title, [users.simon.me.id, users.paul.me.id], function() {
         WhiteboardsTestUtil.assertCreateChatMessage(users.paul.client, course, users.simon.whiteboard.id, 'Chat message 1', function() {
@@ -473,7 +471,7 @@ describe('Daily activity emails', function() {
    * Test that verifies that old data is not used
    */
   it('does not use old data', function(callback) {
-    setupCourseWithActivity(function(dbCourse, course, users) {
+    ActivitiesTestUtil.setupCourseWithActivity(function(dbCourse, course, users) {
 
       // Collect the daily notifications
       var expectedEmailedUsers = [users.nico.me, users.annesophie.me, users.simon.me, users.paul.me];
@@ -494,205 +492,6 @@ describe('Daily activity emails', function() {
       });
     });
   });
-
-  /**
-   * Set up a course with 5 users that each have their own asset and whiteboard.
-   *
-   * Additionally, the following activity takes place:
-   *   - Anne-Sophie comments on Nico's Asset
-   *   - Simon replies to Anne-sophie's comment on Nico's asset
-   *   - Simon adds paul as a whiteboard collaborator
-   *   - Paul creates a chat message on Simon's whiteboard
-   *   - Simon replies to Paul's chat message
-   *   - Simon and Nico comment on Paul's asset
-   *
-   * @param  {Function}     callback                            Standard callback function
-   * @param  {Couse}        callback.dbCourse                   The course in which the activity takes place (database object)
-   * @param  {Couse}        callback.course                     The course in which the activity takes place
-   * @param  {Object}       callback.users                      An object for the 5 created users
-   * @param  {Object}       callback.users.nico                 The information for Nico
-   * @param  {RestClient}   callback.users.nico.client          Nico's rest client
-   * @param  {Object}       callback.users.nico.me              Nico's me feed information
-   * @param  {Object}       callback.users.nico.user            Nico's user object
-   * @param  {Asset}        callback.users.nico.asset           Nico's asset
-   * @param  {Whiteboard}   callback.users.nico.whiteboard      Nico's whiteboard
-   * @param  {Object}       callback.users.annesophie           The information for Anne-Sophie
-   * @param  {Object}       callback.users.simon                The information for Simon
-   * @param  {Object}       callback.users.paul                 The information for Paul
-   * @param  {Object}       callback.users.oliver               The information for Oliver
-   * @throws {AssertionError}                                   Error thrown when an assertion failed
-   * @api private
-   */
-  var setupCourseWithActivity = function(callback) {
-    setupCourse(function(dbCourse, course, users) {
-
-      // The following takes place:
-
-      // This should result in the following emails:
-      //  - To Nico - Anne Sophie and Simon commented on your asset '...'
-      //  - To Anne-Sophie - Simon replied to your comment '...'
-      //  - To Simon - Paul commented on your whiteboard '...'
-      //  - To Paul - Today's activity
-      AssetsTestUtil.assertCreateComment(users.annesophie.client, course, users.nico.asset.id, 'This is a comment by Anne-Sophie', null, function(anneSophiesComment) {
-        AssetsTestUtil.assertCreateComment(users.simon.client, course, users.nico.asset.id, 'This is a reply by Simon', anneSophiesComment.id, function(simonsReply) {
-          WhiteboardsTestUtil.assertEditWhiteboard(users.simon.client, course, users.simon.whiteboard.id, users.simon.whiteboard.title, [users.simon.me.id, users.paul.me.id], function() {
-            WhiteboardsTestUtil.assertCreateChatMessage(users.paul.client, course, users.simon.whiteboard.id, 'Chat message by Paul', function() {
-              WhiteboardsTestUtil.assertCreateChatMessage(users.simon.client, course, users.simon.whiteboard.id, 'Chat message by Simon', function() {
-                AssetsTestUtil.assertCreateComment(users.simon.client, course, users.paul.asset.id, 'This is a comment by Simon', null, function(simonsComment) {
-                  AssetsTestUtil.assertCreateComment(users.nico.client, course, users.paul.asset.id, 'This is a comment by Nico', null, function(nicosComment) {
-
-                    return callback(dbCourse, course, users);
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
-  };
-
-  /**
-   * Set up a course with 5 users that each have their own asset and whiteboard.
-   *
-   * @param  {Function}     callback                            Standard callback function
-   * @param  {Couse}        callback.dbCourse                   The course in which the activity takes place (database object)
-   * @param  {Couse}        callback.course                     The course in which the activity takes place
-   * @param  {Object}       callback.users                      An object for the 5 created users
-   * @param  {Object}       callback.users.nico                 The information for Nico
-   * @param  {RestClient}   callback.users.nico.client          Nico's rest client
-   * @param  {Object}       callback.users.nico.me              Nico's me feed information
-   * @param  {Object}       callback.users.nico.user            Nico's user object
-   * @param  {Asset}        callback.users.nico.asset           Nico's asset
-   * @param  {Whiteboard}   callback.users.nico.whiteboard      Nico's whiteboard
-   * @param  {Object}       callback.users.annesophie           The information for Anne-Sophie
-   * @param  {Object}       callback.users.simon                The information for Simon
-   * @param  {Object}       callback.users.paul                 The information for Paul
-   * @param  {Object}       callback.users.oliver               The information for Oliver
-   * @throws {AssertionError}                                   Error thrown when an assertion failed
-   * @api private
-   */
-  var setupCourse = function(callback) {
-    setupUser(null, function(client1, course, user1, me1, asset1, whiteboard1) {
-      setupUser(course, function(client2, course, user2, me2, asset2, whiteboard2) {
-        setupUser(course, function(client3, course, user3, me3, asset3, whiteboard3) {
-          setupUser(course, function(client4, course, user4, me4, asset4, whiteboard4) {
-            setupUser(course, function(client5, course, user5, me5, asset5, whiteboard5) {
-              setupUser(course, function(client6, course, user6, me6, asset6, whiteboard6) {
-
-                // Launch 1 user into the whiteboards tool so it can be persisted on the course
-                LtiTestUtil.assertWhiteboardsLaunchSucceeds(client1, course, user1, function() {
-
-                  // Get the actual course object so we can pass it into the poller
-                  getCourse(course.id, function(dbCourse) {
-
-                    return callback(dbCourse, course, {
-                      'nico': {
-                        'client': client1,
-                        'user': user1,
-                        'me': me1,
-                        'asset': asset1,
-                        'whiteboard': whiteboard1
-                      },
-                      'annesophie': {
-                        'client': client2,
-                        'user': user2,
-                        'me': me2,
-                        'asset': asset2,
-                        'whiteboard': whiteboard2
-                      },
-                      'paul': {
-                        'client': client3,
-                        'user': user3,
-                        'me': me3,
-                        'asset': asset3,
-                        'whiteboard': whiteboard3
-                      },
-                      'oliver': {
-                        'client': client4,
-                        'user': user4,
-                        'me': me4,
-                        'asset': asset4,
-                        'whiteboard': whiteboard4
-                      },
-                      'simon': {
-                        'client': client5,
-                        'user': user5,
-                        'me': me5,
-                        'asset': asset5,
-                        'whiteboard': whiteboard5
-                      },
-                      'ray': {
-                        'client': client6,
-                        'user': user6,
-                        'me': me6,
-                        'asset': asset6,
-                        'whiteboard': whiteboard6
-                      }
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
-  };
-
-  /**
-   * Set up a user in a course with its own asset and whiteboard
-   *
-   * @param  {Course}         course                  The course in which to set up the user
-   * @param  {Function}       callback                Standard callback function
-   * @param  {Asset}          callback.asset          The user's asset
-   * @param  {Whiteboard}     callback.whiteboard     The user's whiteboard
-   * @throws {AssertionError}                         Error thrown when an assertion failed
-   * @api private
-   */
-  var setupUser = function(course, callback) {
-    TestsUtil.getAssetLibraryClient(null, course, null, function(client, course, user) {
-      UsersTestUtil.assertGetMe(client, course, null, function(me) {
-
-        // Create an asset for the user
-        var assetTitle = randomstring.generate(25);
-        AssetsTestUtil.assertCreateLink(client, course, assetTitle, 'http://www.google.com', null, function(asset) {
-
-          // Create a whiteboard for the user
-          var whiteboardTitle = randomstring.generate(25);
-          WhiteboardsTestUtil.assertCreateWhiteboard(client, course, whiteboardTitle, null, function(whiteboard) {
-            return callback(client, course, user, me, asset, whiteboard);
-          });
-        });
-      })
-    });
-  };
-
-  /**
-   * Get a course object given a Canvas course id
-   *
-   * @param  {Number}           canvasCourseId      The id of the course in Canvas
-   * @param  {Function}         callback            Invoked when the course has been retrieved
-   * @param  {Course}           callback.course     The retrieved course object
-   * @throws {AssertionError}                       Error thrown when an assertion failed
-   * @api private
-   */
-  var getCourse = function(canvasCourseId, callback) {
-    var options = {
-      'where': {
-        'canvas_course_id': canvasCourseId
-      },
-      'include': [{
-        'model': DB.Canvas,
-        'as': 'canvas'
-      }]
-    };
-    DB.Course.findOne(options).complete(function(err, course) {
-      assert.ok(!err);
-      assert.ok(course);
-      return callback(course);
-    });
-  };
 
   /**
    * Given a set of collected emails, get the one matching a specific email address

--- a/node_modules/col-activities/tests/test-weekly.js
+++ b/node_modules/col-activities/tests/test-weekly.js
@@ -23,28 +23,43 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-module.exports = {
-  "analytics": {
-    "enabled": false
-  },
-  "db": {
-    "database": "collabospheretest",
-    "dropOnStartup": true
-  },
-  "log": {
-    "level": "trace",
-    "stream": "logs/test.log"
-  },
-  "canvasPoller": {
-    "enabled": false
-  },
-  "previews": {
-    "enabled": false
-  },
-  "email": {
-    "enabled": false,
-    // We set these values two hours in the future so that the integration tests will pick up just-created activities. 
-    "dailyHour": ((new Date().getHours() + 2) % 34),
-    "weeklyHour": ((new Date().getHours() + 2) % 34)
-  }
-}
+var _ = require('lodash');
+var assert = require('assert');
+
+var AssetsTestUtil = require('col-assets/tests/util');
+var TestsUtil = require('col-tests');
+var UsersTestUtil = require('col-users/tests/util');
+
+var ActivitiesDefaults = require('col-activities/lib/default');
+var ActivitiesTestUtil = require('./util');
+
+describe('Weekly activity emails', function() {
+
+  /**
+   * Test that verifies authorization when manually triggering a weekly activity email for a course
+   */
+  it('verifies authorization', function(callback) {
+    TestsUtil.getAssetLibraryClient(null, null, null, function(client, course, user) {
+      ActivitiesTestUtil.assertSendWeeklyNotificationsFails(client, course, 401, function() {
+
+        return callback();
+      });
+    });
+  });
+
+  /**
+   * Test that verifies that emails are sent to active users in a course
+   */
+  it('sends emails to all active users in a course', function(callback) {
+    ActivitiesTestUtil.setupCourseWithInstructor(function(dbCourse, course, users, instructor) {
+      var userObjects = _.map(users, function(user) { 
+        return user.me; 
+      });
+
+      // Verify that everyone gets an email
+      ActivitiesTestUtil.assertSendWeeklyNotifications(users.instructor.client, course, dbCourse, userObjects, function(emails) {
+        return callback();
+      });
+    });
+  });
+});

--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -26,9 +26,12 @@
 var _ = require('lodash');
 var assert = require('assert');
 var csv = require('fast-csv');
+var randomstring = require('randomstring');
 
 var AssetsTestUtil = require('col-assets/tests/util');
+var DB = require('col-core/lib/db');
 var EmailUtil = require('col-core/lib/email');
+var LtiTestUtil = require('col-lti/tests/util');
 var TestsUtil = require('col-tests');
 var UsersTestUtil = require('col-users/tests/util');
 var WhiteboardsTestUtil = require('col-whiteboards/tests/util');
@@ -760,34 +763,327 @@ var assertDailyNotifications = module.exports.assertDailyNotifications = functio
   // Send out the daily notifications
   var DailyNotifications = require('../lib/notifications/daily');
   DailyNotifications.collectCourse(course, function() {
-
     EmailUtil.removeListener(EmailUtil.EVENT_NAMES.EMAIL_SENT, emailListener);
-
-    // Verify the correct number of emails were sent
-    assert.strictEqual(_.size(emails), _.size(users));
-
-    // Verify the notifications were sent to the correct users
-    if (users) {
-      var emailAddresses = _.chain(emails)
-        .pluck('email')
-        .pluck('to')
-        .value()
-        .sort();
-
-      var expectedEmailAddresses = _.pluck(users, 'canvas_email').sort();
-      assert.deepEqual(emailAddresses, expectedEmailAddresses);
-
-      // Verify the correct name was used when addressing the user
-      var emailNames = _.chain(emails)
-        .pluck('email')
-        .pluck('toname')
-        .value()
-        .sort();
-
-      var expectedEmailNames = _.pluck(users, 'canvas_full_name').sort();
-      assert.deepEqual(emailNames, expectedEmailNames);
-    }
+    assertEmailsForUsers(emails, users);
 
     return callback(emails);
+  });
+};
+
+/**
+ * Assert that weekly notification emails are sent
+ *
+ * @param  {RestClient}          client                           The REST client to make the request with
+ * @param  {Course}              course                           The Canvas course in which the user is interacting with the API
+ * @param  {Course}              dbCourse                         The database model for the course
+ * @param  {User[]}              users                            The users who should receive an email
+ * @param  {Function}            callback                         Standard callback function
+ * @param  {Object[]}            callback.emails                  The sent email messages
+ * @param  {Object}              callback.emails[i].email         Information including the subject, html body, recipient
+ * @param  {User}                callback.emails[i].user          The user to whom the email was sent
+ * @param  {Course}              callback.emails[i].course        The course for which the email was sent
+ * @throws {AssertionError}                                       Error thrown when an assertion fails
+ */
+var assertSendWeeklyNotifications = module.exports.assertSendWeeklyNotifications = function(client, course, dbCourse, users, callback) {
+  // Collect any emails that are sent out when collecting the weekly notifications
+  var emails = [];
+  function emailListener(email, user, dbCourse) {
+    emails.push({
+      'email': email,
+      'user': user,
+      'course': dbCourse
+    });
+  };
+  EmailUtil.on(EmailUtil.EVENT_NAMES.EMAIL_SENT, emailListener);
+
+  client.activities.sendWeeklyNotificationsForCourse(course, function(err, response) {
+    assert.ok(!err);
+    assert.ok(response);
+
+    EmailUtil.removeListener(EmailUtil.EVENT_NAMES.EMAIL_SENT, emailListener);
+    assertEmailsForUsers(emails, users);
+
+    return callback(emails);
+  });
+};
+
+/**
+ * Assert that a set of email messages matches user data
+ * @param  {User[]}              users                     The users who should have received an email
+ * @param  {Object[]}            emails                    The sent email messages
+ * @api private
+ */
+var assertEmailsForUsers = function(emails, users) {
+  // Verify the correct number of emails was sent
+  assert.strictEqual(_.size(emails), _.size(users));
+
+  // Verify the notifications were sent to the correct users
+  if (users) {
+    var emailAddresses = _.chain(emails)
+      .pluck('email')
+      .pluck('to')
+      .value()
+      .sort();
+
+    var expectedEmailAddresses = _.pluck(users, 'canvas_email').sort();
+    assert.deepEqual(emailAddresses, expectedEmailAddresses);
+
+    // Verify the correct name was used when addressing the user
+    var emailNames = _.chain(emails)
+      .pluck('email')
+      .pluck('toname')
+      .value()
+      .sort();
+
+    var expectedEmailNames = _.pluck(users, 'canvas_full_name').sort();
+    assert.deepEqual(emailNames, expectedEmailNames);
+  }
+};
+
+/**
+ * Assert that the weekly notification email for a course can not be manually triggered
+ *
+ * @param  {RestClient}         client                            The REST client to make the request with
+ * @param  {Course}             course                            The Canvas course in which the user is interacting with the API
+ * @param  {Number}             code                              The expected HTTP error code
+ * @param  {Function}           callback                          Standard callback function
+ * @param  {Object}             callback.configuration            The activity type configuration for the course
+ * @throws {AssertionError}                                       Error thrown when an assertion failed
+ */
+var assertSendWeeklyNotificationsFails = module.exports.assertSendWeeklyNotificationsFails = function(client, course, code, callback) {
+  client.activities.sendWeeklyNotificationsForCourse(course, function(err, response) {
+    assert.ok(err);
+    assert.strictEqual(err.code, code);
+    assert.ok(!response);
+
+    return callback();
+  });
+};
+
+
+/* Utilities specific to notification email tests */
+
+
+/**
+ * Get a course object given a Canvas course id
+ *
+ * @param  {Number}           canvasCourseId      The id of the course in Canvas
+ * @param  {Function}         callback            Invoked when the course has been retrieved
+ * @param  {Course}           callback.course     The retrieved course object
+ * @throws {AssertionError}                       Error thrown when an assertion failed
+ * @api private
+ */
+var getCourse = function(canvasCourseId, callback) {
+  var options = {
+    'where': {
+      'canvas_course_id': canvasCourseId
+    },
+    'include': [{
+      'model': DB.Canvas,
+      'as': 'canvas'
+    }]
+  };
+  DB.Course.findOne(options).complete(function(err, course) {
+    assert.ok(!err);
+    assert.ok(course);
+    return callback(course);
+  });
+};
+
+/**
+ * Set up a course with 6 users that each have their own asset and whiteboard.
+ *
+ * @param  {Function}     callback                            Standard callback function
+ * @param  {Couse}        callback.dbCourse                   The course in which the activity takes place (database object)
+ * @param  {Couse}        callback.course                     The course in which the activity takes place
+ * @param  {Object}       callback.users                      An object for the 5 created users
+ * @param  {Object}       callback.users.nico                 The information for Nico
+ * @param  {RestClient}   callback.users.nico.client          Nico's rest client
+ * @param  {Object}       callback.users.nico.me              Nico's me feed information
+ * @param  {Object}       callback.users.nico.user            Nico's user object
+ * @param  {Asset}        callback.users.nico.asset           Nico's asset
+ * @param  {Whiteboard}   callback.users.nico.whiteboard      Nico's whiteboard
+ * @param  {Object}       callback.users.annesophie           The information for Anne-Sophie
+ * @param  {Object}       callback.users.simon                The information for Simon
+ * @param  {Object}       callback.users.paul                 The information for Paul
+ * @param  {Object}       callback.users.oliver               The information for Oliver
+ * @throws {AssertionError}                                   Error thrown when an assertion failed
+ * @api private
+ */
+var setupCourse = module.exports.setupCourse = function(callback) {
+  setupUser(null, function(client1, course, user1, me1, asset1, whiteboard1) {
+    setupUser(course, function(client2, course, user2, me2, asset2, whiteboard2) {
+      setupUser(course, function(client3, course, user3, me3, asset3, whiteboard3) {
+        setupUser(course, function(client4, course, user4, me4, asset4, whiteboard4) {
+          setupUser(course, function(client5, course, user5, me5, asset5, whiteboard5) {
+            setupUser(course, function(client6, course, user6, me6, asset6, whiteboard6) {
+
+              // Launch 1 user into the whiteboards tool so it can be persisted on the course
+              LtiTestUtil.assertWhiteboardsLaunchSucceeds(client1, course, user1, function() {
+
+                // Get the actual course object so we can pass it into the poller
+                getCourse(course.id, function(dbCourse) {
+
+                  return callback(dbCourse, course, {
+                    'nico': {
+                      'client': client1,
+                      'user': user1,
+                      'me': me1,
+                      'asset': asset1,
+                      'whiteboard': whiteboard1
+                    },
+                    'annesophie': {
+                      'client': client2,
+                      'user': user2,
+                      'me': me2,
+                      'asset': asset2,
+                      'whiteboard': whiteboard2
+                    },
+                    'paul': {
+                      'client': client3,
+                      'user': user3,
+                      'me': me3,
+                      'asset': asset3,
+                      'whiteboard': whiteboard3
+                    },
+                    'oliver': {
+                      'client': client4,
+                      'user': user4,
+                      'me': me4,
+                      'asset': asset4,
+                      'whiteboard': whiteboard4
+                    },
+                    'simon': {
+                      'client': client5,
+                      'user': user5,
+                      'me': me5,
+                      'asset': asset5,
+                      'whiteboard': whiteboard5
+                    },
+                    'ray': {
+                      'client': client6,
+                      'user': user6,
+                      'me': me6,
+                      'asset': asset6,
+                      'whiteboard': whiteboard6
+                    }
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+};
+
+/**
+ * Set up a course with 6 users that each have their own asset and whiteboard.
+ * Additionally, add a seventh user with an instructor role.
+ *
+ * @param  {Function}     callback                            Standard callback function
+ * @param  {Couse}        callback.dbCourse                   The course in which the activity takes place (database object)
+ * @param  {Couse}        callback.course                     The course in which the activity takes place
+ * @param  {Object}       callback.users                      An object for the 7 created users
+ */
+var setupCourseWithInstructor = module.exports.setupCourseWithInstructor = function(callback) {
+  setupCourse(function(dbCourse, course, users) {
+    var instructor = TestsUtil.generateInstructor();
+    TestsUtil.getAssetLibraryClient(null, course, instructor, function(instructorClient, course, instructor) {
+      UsersTestUtil.assertGetMe(instructorClient, course, null, function(instructorMe) {
+        users.instructor = {
+          'client': instructorClient,
+          'user': instructor,
+          'me': instructorMe
+        };
+        return callback(dbCourse, course, users);
+      });
+    });
+  });
+};
+
+/**
+ * Set up a course with 6 users that each have their own asset and whiteboard.
+ *
+ * Additionally, the following activity takes place:
+ *   - Anne-Sophie comments on Nico's Asset
+ *   - Simon replies to Anne-sophie's comment on Nico's asset
+ *   - Simon adds paul as a whiteboard collaborator
+ *   - Paul creates a chat message on Simon's whiteboard
+ *   - Simon replies to Paul's chat message
+ *   - Simon and Nico comment on Paul's asset
+ *
+ * @param  {Function}     callback                            Standard callback function
+ * @param  {Couse}        callback.dbCourse                   The course in which the activity takes place (database object)
+ * @param  {Couse}        callback.course                     The course in which the activity takes place
+ * @param  {Object}       callback.users                      An object for the 6 created users
+ * @param  {Object}       callback.users.nico                 The information for Nico
+ * @param  {RestClient}   callback.users.nico.client          Nico's rest client
+ * @param  {Object}       callback.users.nico.me              Nico's me feed information
+ * @param  {Object}       callback.users.nico.user            Nico's user object
+ * @param  {Asset}        callback.users.nico.asset           Nico's asset
+ * @param  {Whiteboard}   callback.users.nico.whiteboard      Nico's whiteboard
+ * @param  {Object}       callback.users.annesophie           The information for Anne-Sophie
+ * @param  {Object}       callback.users.simon                The information for Simon
+ * @param  {Object}       callback.users.paul                 The information for Paul
+ * @param  {Object}       callback.users.oliver               The information for Oliver
+ * @throws {AssertionError}                                   Error thrown when an assertion failed
+ * @api private
+ */
+var setupCourseWithActivity = module.exports.setupCourseWithActivity = function(callback) {
+  setupCourse(function(dbCourse, course, users) {
+
+    // The following takes place:
+
+    // This should result in the following emails:
+    //  - To Nico - Anne Sophie and Simon commented on your asset '...'
+    //  - To Anne-Sophie - Simon replied to your comment '...'
+    //  - To Simon - Paul commented on your whiteboard '...'
+    //  - To Paul - Today's activity
+    AssetsTestUtil.assertCreateComment(users.annesophie.client, course, users.nico.asset.id, 'This is a comment by Anne-Sophie', null, function(anneSophiesComment) {
+      AssetsTestUtil.assertCreateComment(users.simon.client, course, users.nico.asset.id, 'This is a reply by Simon', anneSophiesComment.id, function(simonsReply) {
+        WhiteboardsTestUtil.assertEditWhiteboard(users.simon.client, course, users.simon.whiteboard.id, users.simon.whiteboard.title, [users.simon.me.id, users.paul.me.id], function() {
+          WhiteboardsTestUtil.assertCreateChatMessage(users.paul.client, course, users.simon.whiteboard.id, 'Chat message by Paul', function() {
+            WhiteboardsTestUtil.assertCreateChatMessage(users.simon.client, course, users.simon.whiteboard.id, 'Chat message by Simon', function() {
+              AssetsTestUtil.assertCreateComment(users.simon.client, course, users.paul.asset.id, 'This is a comment by Simon', null, function(simonsComment) {
+                AssetsTestUtil.assertCreateComment(users.nico.client, course, users.paul.asset.id, 'This is a comment by Nico', null, function(nicosComment) {
+
+                  return callback(dbCourse, course, users);
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+};
+
+/**
+ * Set up a user in a course with its own asset and whiteboard
+ *
+ * @param  {Course}         course                  The course in which to set up the user
+ * @param  {Function}       callback                Standard callback function
+ * @param  {Asset}          callback.asset          The user's asset
+ * @param  {Whiteboard}     callback.whiteboard     The user's whiteboard
+ * @throws {AssertionError}                         Error thrown when an assertion failed
+ * @api private
+ */
+var setupUser = function(course, callback) {
+  TestsUtil.getAssetLibraryClient(null, course, null, function(client, course, user) {
+    UsersTestUtil.assertGetMe(client, course, null, function(me) {
+
+      // Create an asset for the user
+      var assetTitle = randomstring.generate(25);
+      AssetsTestUtil.assertCreateLink(client, course, assetTitle, 'http://www.google.com', null, function(asset) {
+
+        // Create a whiteboard for the user
+        var whiteboardTitle = randomstring.generate(25);
+        WhiteboardsTestUtil.assertCreateWhiteboard(client, course, whiteboardTitle, null, function(whiteboard) {
+          return callback(client, course, user, me, asset, whiteboard);
+        });
+      });
+    })
   });
 };

--- a/node_modules/col-rest/lib/rest/activities.js
+++ b/node_modules/col-rest/lib/rest/activities.js
@@ -74,4 +74,19 @@ module.exports = function(client) {
     var requestUrl = client.util.apiPrefix(course) + '/activities/configuration';
     client.jsonPost(requestUrl, activityTypeUpdates, null, callback);
   };
+
+  /*
+   * Manually trigger the weekly email notification for a course
+   * @param  {Course}         course                            The Canvas course in which the user is interacting with the API
+   * @param  {Function}       callback                          Standard callback function
+   * @param  {Object}         callback.err                      An error that occurred, if any
+   * @param  {Object}         callback.body                     The JSON response from the REST API
+   * @param  {Response}       callback.response                 The response object as returned by requestjs
+   * @see col-activities/lib/rest.js for more information
+   */
+
+  client.activities.sendWeeklyNotificationsForCourse = function(course, callback) {
+    var requestUrl = client.util.apiPrefix(course) + '/activities/notifications/send_weekly';
+    client.request(requestUrl, 'GET', null, null, callback);
+  };  
 };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-425

An admin-only magic URL is exposed to trigger the weekly email. This URL is also used for the first integration tests; more to come. 

Note that many utility functions are moved from `node_modules/col-activities/tests/test-daily.js` into `node_modules/col-activities/tests/util.js` so that both daily and the weekly email tests can use them.