### PR TITLE
COL-434 Add per-course engagementindex_url property

### DIFF
--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -190,6 +190,7 @@ var setUpModel = function(sequelize) {
    * @property  {Boolean}     enable_upload                 Whether students are allowed to upload to the Asset Library directly
    * @property  {String}      name                          The name of the course
    * @property  {String}      assetlibrary_url              The URL where the asset library in this course can be reached
+   * @property  {String}      engagementindex_url           The URL where the engagement index in this course can be reached
    * @property  {String}      whiteboards_url               The URL where the whiteboards in this course can be reached
    * @property  {Boolean}     active                        Whether this course's data should be synced with Canvas
    * @property  {Date}        enable_assignment_sync_from   If present, timestamp after which Canvas assignments should be synced with Asset Library
@@ -209,6 +210,10 @@ var setUpModel = function(sequelize) {
       'allowNull': true
     },
     'assetlibrary_url': {
+      'type': Sequelize.STRING,
+      'allowNull': true
+    },
+    'engagementindex_url': {
       'type': Sequelize.STRING,
       'allowNull': true
     },

--- a/node_modules/col-course/lib/api.js
+++ b/node_modules/col-course/lib/api.js
@@ -36,6 +36,7 @@ var log = require('col-core/lib/logger')('col-course');
  * @param  {Object}       courseInfo                        Additional info for the course
  * @param  {String}       [courseInfo.name]                 The name of the course
  * @param  {String}       [courseInfo.assetlibrary_url]     The URL where the asset library in this course can be reached
+ * @param  {String}       [courseInfo.engagementindex_url]  The URL where the engagement index in this course can be reached
  * @param  {String}       [courseInfo.whiteboards_url]      The URL where the whiteboards in this course can be reached
  * @param  {Function}     callback                          Standard callback function
  * @param  {Object}       callback.err                      An error object, if any
@@ -49,6 +50,7 @@ var getOrCreateCourse = module.exports.getOrCreateCourse = function(canvasCourse
     'courseInfo': Joi.object().keys({
       'name': Joi.string().optional(),
       'assetlibrary_url': Joi.string().optional(),
+      'engagementindex_url': Joi.string().optional(),
       'whiteboards_url': Joi.string().optional()
     }).optional()
   });
@@ -72,6 +74,7 @@ var getOrCreateCourse = module.exports.getOrCreateCourse = function(canvasCourse
       'canvas_api_domain': canvas.canvas_api_domain,
       'name': courseInfo.name,
       'assetlibrary_url': courseInfo.assetlibrary_url,
+      'engagementindex_url': courseInfo.engagementindex_url,
       'whiteboards_url': courseInfo.whiteboards_url
     }
   };
@@ -138,7 +141,7 @@ var getCourse = module.exports.getCourse = function(id, callback) {
  */
 var getCoursePublic = module.exports.getCoursePublic = function(ctx, callback) {
   var options = {
-    'attributes': ['id', 'name', 'canvas_course_id', 'active', 'whiteboards_url', 'assetlibrary_url', 'enable_assignment_sync_from', 'enable_upload']
+    'attributes': ['id', 'name', 'canvas_course_id', 'active', 'whiteboards_url', 'assetlibrary_url', 'engagementindex_url', 'enable_assignment_sync_from', 'enable_upload']
   };
   DB.Course.findById(ctx.course.id, options).complete(function(err, course) {
     if (err) {

--- a/node_modules/col-lti/lib/api.js
+++ b/node_modules/col-lti/lib/api.js
@@ -113,6 +113,8 @@ var launch = module.exports.launch = function(req, toolId, callback) {
       };
       if (toolId === 'assetlibrary') {
         courseInfo.assetlibrary_url = req.headers.referer;
+      } else if (toolId === 'engagementindex') {
+        courseInfo.engagementindex_url = req.headers.referer;
       } else if (toolId === 'whiteboards') {
         courseInfo.whiteboards_url = req.headers.referer;
       }

--- a/scripts/20160824-col434/add_course_engagementindex_url.sql
+++ b/scripts/20160824-col434/add_course_engagementindex_url.sql
@@ -1,0 +1,5 @@
+-- Add a per-course column containing the URL for the engagement index tool. Like the existing
+-- assetlibrary_url and whiteboards_url columns, this column defaults to null and is populated with
+-- the correct URL the first time the tool is launched.
+
+ALTER TABLE courses ADD engagementindex_url varchar(255);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-434

The weekly email requires a stored URL for the engagement index, as we already do for the other two SuiteC tools.