### PR TITLE
COL-424 Weekly email: anonymize users not opted into engagement index

### DIFF
--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -406,9 +406,16 @@ var summarizeActivities = function(activities, activityTypeConfiguration, users)
   _.forEach(['pointsGenerated', 'pointsReceived'], function(key) {
     var topUser = sampleMaximum(summary.users, _.property(key));
     if (topUser) {
+      var total = topUser.value;
+      var user = users[topUser.id];
+      // If a user has not opted into the engagement index, do not pass on identifying information.
+      if (!user.share_points) {
+        user = {};
+      }
+
       summary.course.topUsers[key] = {
-        'total': topUser.value,
-        'user': users[topUser.id]
+        'total': total,
+        'user': user
       };
     }
   });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-424

The weekly email front end is already set up to show a placeholder icon for users lacking properties.

Test coverage for this feature will come with the rest of the integration suite.