### PR TITLE
COL-395 Add view_asset activity type

### DIFF
--- a/node_modules/col-activities/lib/default.js
+++ b/node_modules/col-activities/lib/default.js
@@ -25,6 +25,12 @@
 
 var Default = module.exports = [
   {
+    'type': 'view_asset',
+    'title': 'View an asset in the Asset Library',
+    'points': 0,
+    'enabled': true
+  },
+  {
     'type': 'add_asset',
     'title': 'Add a new asset to the Asset Library',
     'points': 5,

--- a/node_modules/col-activities/tests/test-csv.js
+++ b/node_modules/col-activities/tests/test-csv.js
@@ -42,36 +42,44 @@ describe('Activities', function() {
       var instructor = TestsUtil.generateInstructor();
       TestsUtil.getAssetLibraryClient(null, null, instructor, function(client1, course, instructor) {
 
-        // Verify that the activity CSV export is empty before any activities have taken place
-        ActivitiesTestUtil.assertExportActivities(client1, course, 0, function(activities) {
+        // Disable the `view_asset` activity to reduce noise in activity logging
+        var activityTypeOverride = [{
+          'type': 'view_asset',
+          'enabled': false
+        }];
+        ActivitiesTestUtil.assertEditActivityTypeConfiguration(client1, course, activityTypeOverride, function() {
 
-          // Verify that adding a new asset is reflected in the activities CSV export
-          TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
-            ActivitiesTestUtil.assertCreateLinkActivity(client2, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
-              ActivitiesTestUtil.assertExportActivities(client1, course, 1, function(activities) {
-                assert.strictEqual(activities[0].action, 'add_asset');
+          // Verify that the activity CSV export is empty before any activities have taken place
+          ActivitiesTestUtil.assertExportActivities(client1, course, 0, function(activities) {
 
-                // Verify that liking an asset is reflected in the activities CSV export
-                TestsUtil.getAssetLibraryClient(null, course, null, function(client3, course, user3) {
-                  ActivitiesTestUtil.assertLikeActivity(client3, client2, course, asset.id, true, function() {
-                    ActivitiesTestUtil.assertExportActivities(client1, course, 3, function(activities) {
-                      assert.strictEqual(activities[0].action, 'add_asset');
-                      assert.strictEqual(activities[1].action, 'like');
-                      assert.strictEqual(activities[2].action, 'get_like');
+            // Verify that adding a new asset is reflected in the activities CSV export
+            TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
+              ActivitiesTestUtil.assertCreateLinkActivity(client2, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
+                ActivitiesTestUtil.assertExportActivities(client1, course, 1, function(activities) {
+                  assert.strictEqual(activities[0].action, 'add_asset');
 
-                      // Verify that replacing an activity is reflected in the activities CSV export
-                      ActivitiesTestUtil.assertLikeActivity(client3, client2, course, asset.id, false, function() {
-                        ActivitiesTestUtil.assertExportActivities(client1, course, 3, function(activities) {
-                          assert.strictEqual(activities[0].action, 'add_asset');
-                          assert.strictEqual(activities[1].action, 'dislike');
-                          assert.strictEqual(activities[2].action, 'get_dislike');
+                  // Verify that liking an asset is reflected in the activities CSV export
+                  TestsUtil.getAssetLibraryClient(null, course, null, function(client3, course, user3) {
+                    ActivitiesTestUtil.assertLikeActivity(client3, client2, course, asset.id, true, function() {
+                      ActivitiesTestUtil.assertExportActivities(client1, course, 3, function(activities) {
+                        assert.strictEqual(activities[0].action, 'add_asset');
+                        assert.strictEqual(activities[1].action, 'like');
+                        assert.strictEqual(activities[2].action, 'get_like');
 
-                          // Verify that removing an activity is reflected in the activities CSV export
-                          ActivitiesTestUtil.assertLikeActivity(client3, client2, course, asset.id, null, function() {
-                            ActivitiesTestUtil.assertExportActivities(client1, course, 1, function(activities) {
-                              assert.strictEqual(activities[0].action, 'add_asset');
+                        // Verify that replacing an activity is reflected in the activities CSV export
+                        ActivitiesTestUtil.assertLikeActivity(client3, client2, course, asset.id, false, function() {
+                          ActivitiesTestUtil.assertExportActivities(client1, course, 3, function(activities) {
+                            assert.strictEqual(activities[0].action, 'add_asset');
+                            assert.strictEqual(activities[1].action, 'dislike');
+                            assert.strictEqual(activities[2].action, 'get_dislike');
 
-                              return callback();
+                            // Verify that removing an activity is reflected in the activities CSV export
+                            ActivitiesTestUtil.assertLikeActivity(client3, client2, course, asset.id, null, function() {
+                              ActivitiesTestUtil.assertExportActivities(client1, course, 1, function(activities) {
+                                assert.strictEqual(activities[0].action, 'add_asset');
+
+                                return callback();
+                              });
                             });
                           });
                         });
@@ -109,37 +117,45 @@ describe('Activities', function() {
         TestsUtil.getAssetLibraryClient(null, course, null, function(studentClient1, course, studentUser1) {
           TestsUtil.getAssetLibraryClient(null, course, null, function(studentClient2, course, studentUser2) {
 
-            // Generate a few activities by creating a link and liking it
-            ActivitiesTestUtil.assertCreateLinkActivity(studentClient1, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
-              ActivitiesTestUtil.assertLikeActivity(studentClient2, studentClient1, course, asset.id, true, function() {
+            // Disable the `view_asset` activity to reduce noise in activity logging
+            var activityTypeOverride = [{
+              'type': 'view_asset',
+              'enabled': false
+            }];
+            ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
 
-                // Sanity check the activities have been created and are all included in the export
-                ActivitiesTestUtil.assertExportActivities(instructorClient, course, 3, function(activities) {
-                  assert.strictEqual(activities[0].action, 'add_asset');
-                  assert.strictEqual(activities[1].action, 'like');
-                  assert.strictEqual(activities[2].action, 'get_like');
+              // Generate a few activities by creating a link and liking it
+              ActivitiesTestUtil.assertCreateLinkActivity(studentClient1, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
+                ActivitiesTestUtil.assertLikeActivity(studentClient2, studentClient1, course, asset.id, true, function() {
 
-                  // Disable the `add_asset` activity
-                  var activityTypeOverride = [{
-                    'type': 'add_asset',
-                    'enabled': false
-                  }];
-                  ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
+                  // Sanity check the activities have been created and are all included in the export
+                  ActivitiesTestUtil.assertExportActivities(instructorClient, course, 3, function(activities) {
+                    assert.strictEqual(activities[0].action, 'add_asset');
+                    assert.strictEqual(activities[1].action, 'like');
+                    assert.strictEqual(activities[2].action, 'get_like');
 
-                    // Verify the `add_asset` activity is not included in the export
-                    ActivitiesTestUtil.assertExportActivities(instructorClient, course, 2, function(activities) {
-                      assert.strictEqual(activities[0].action, 'like');
-                      assert.strictEqual(activities[1].action, 'get_like');
+                    // Disable the `add_asset` activity
+                    var activityTypeOverride = [{
+                      'type': 'add_asset',
+                      'enabled': false
+                    }];
+                    ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
 
-                      // Re-enable the `add_asset` activity and verify it's included in the export
-                      activityTypeOverride[0].enabled = true;
-                      ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
-                        ActivitiesTestUtil.assertExportActivities(instructorClient, course, 3, function(activities) {
-                          assert.strictEqual(activities[0].action, 'add_asset');
-                          assert.strictEqual(activities[1].action, 'like');
-                          assert.strictEqual(activities[2].action, 'get_like');
+                      // Verify the `add_asset` activity is not included in the export
+                      ActivitiesTestUtil.assertExportActivities(instructorClient, course, 2, function(activities) {
+                        assert.strictEqual(activities[0].action, 'like');
+                        assert.strictEqual(activities[1].action, 'get_like');
 
-                          return callback();
+                        // Re-enable the `add_asset` activity and verify it's included in the export
+                        activityTypeOverride[0].enabled = true;
+                        ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
+                          ActivitiesTestUtil.assertExportActivities(instructorClient, course, 3, function(activities) {
+                            assert.strictEqual(activities[0].action, 'add_asset');
+                            assert.strictEqual(activities[1].action, 'like');
+                            assert.strictEqual(activities[2].action, 'get_like');
+
+                            return callback();
+                          });
                         });
                       });
                     });

--- a/node_modules/col-activities/tests/test-points.js
+++ b/node_modules/col-activities/tests/test-points.js
@@ -120,6 +120,47 @@ describe('Activity Points', function() {
     });
   });
 
+  describe('Viewing an asset', function() {
+
+    /**
+     * Test that verifies that viewing an asset updates points only when points are overridden
+     */
+    it('updates points only when points are overridden', function(callback) {
+      TestsUtil.getAssetLibraryClient(null, null, null, function(client1, course, user) {
+        ActivitiesTestUtil.assertCreateLinkActivity(client1, course, 'UC Davis', 'http://www.ucdavis.edu/', null, function(asset) {
+
+          // Verify that viewing an asset does not update points by default
+          TestsUtil.getAssetLibraryClient(null, course, null, function(client2, course, user2) {
+            ActivitiesTestUtil.assertViewAssetActivity(client2, course, asset.id, function() {
+
+              // Assign points to asset view
+              var instructorUser = TestsUtil.generateInstructor();
+              TestsUtil.getAssetLibraryClient(null, course, instructorUser, function(instructorClient, course, instructorUser) {
+
+                var activityTypeOverride = [{
+                  'type': 'view_asset',
+                  'points': 2
+                }];
+                ActivitiesTestUtil.assertEditActivityTypeConfiguration(instructorClient, course, activityTypeOverride, function() {
+
+                  // Verify that viewing an asset now updates points
+                  ActivitiesTestUtil.assertViewAssetActivity(client2, course, asset.id, function() {
+
+                    // Verify that a user viewing their own asset does not update points
+                    ActivitiesTestUtil.assertViewAssetActivity(client1, course, asset.id, function() {                    
+
+                      return callback();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe('Liking', function() {
 
     /**

--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -486,21 +486,24 @@ var assertDeleteReplyActivity = module.exports.assertDeleteReplyActivity = funct
 
               // A commenter who deleted a reply to their own comment on another user's asset
               } else if (commenterMe.id !== creatorMe.id && commenterMe.id === parentMe.id) {
-                assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, false, function() {
+                // Commenter activity timestamp is incremented for the 'view' activity; creator activity timestamp is not.
+                assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, true, function() {
                   assertPoints(creatorClient, course, creatorMe, -1 * getAssetCommentPoints, false, callback);
                 });
 
               // A commenter who deletes a reply to a comment of another user on another user's asset where the asset
               // creator is the same user as the parent commenter
               } else if (commenterMe.id !== creatorMe.id && commenterMe.id !== parentMe.id && parentMe.id === creatorMe.id) {
-                assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, false, function() {
+                // Commenter activity timestamp is incremented for the 'view' activity; creator activity timestamp is not.
+                assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, true, function() {
                   assertPoints(parentClient, course, parentMe, -1 * (getAssetCommentReplyPoints + getAssetCommentPoints), false, callback);
                 });
 
               // A commenter who deletes a reply to a comment of another user on another user's asset where the asset
               // creator is different from the parent commenter
               } else if (commenterMe.id !== creatorMe.id && commenterMe.id !== parentMe.id && parentMe.id !== creatorMe.id) {
-                assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, false, function() {
+                // Commenter activity timestamp is incremented for the 'view' activity; creator activity timestamp is not.
+                assertPoints(commenterClient, course, commenterMe, -1 * assetCommentPoints, true, function() {
                   assertPoints(parentClient, course, parentMe, -1 * getAssetCommentReplyPoints, false, function() {
                     assertPoints(creatorClient, course, creatorMe, -1 * getAssetCommentPoints, false, callback);
                   });
@@ -547,7 +550,9 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
             if (asset.liked === null) {
               // No point changes are expected
               if (like === null) {
-                assertPoints(likerClient, course, likerMe, 0, false, function() {
+                // The liker client has an updated timestamp from the view activity, but no updated points
+                assertPoints(likerClient, course, likerMe, 0, true, function() {
+                  // The creator client has no updated points or timestamp
                   assertPoints(creatorClient, course, creatorMe, 0, false, callback);
                 });
               // Points for liking are expected to be rewarded to the user liking and the user receiving the like
@@ -565,7 +570,9 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
             } else if (asset.liked === true) {
               // Points for liking are expected to be removed from the user that liked and the user that received the like
               if (like === null) {
-                assertPoints(likerClient, course, likerMe, -likePoints, false, function() {
+                // The liker client has an updated timestamp from the view activity, but no updated points
+                assertPoints(likerClient, course, likerMe, -likePoints, true, function() {
+                  // The creator client has no updated points or timestamp
                   assertPoints(creatorClient, course, creatorMe, -getLikePoints, false, callback);
                 });
               // No point changes are expected
@@ -584,7 +591,9 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
             } else if (asset.liked === false) {
               // Points for disliking are expected to be removed from the user that disliked and the user that received the dislike
               if (like === null) {
-                assertPoints(likerClient, course, likerMe, -dislikePoints, false, function() {
+                // The liker client has an updated timestamp from the view activity, but no updated points
+                assertPoints(likerClient, course, likerMe, -dislikePoints, true, function() {
+                  // The creator client has no updated points or timestamp
                   assertPoints(creatorClient, course, creatorMe, -getDislikePoints, false, callback);
                 });
               // Points for disliking are expected to be removed from the user that disliked and the user that received the dislike
@@ -602,6 +611,48 @@ var assertLikeActivity = module.exports.assertLikeActivity = function(likerClien
             }
           });
         });
+      });
+    });
+  });
+};
+
+/**
+ * Assert that an asset can be viewed and activity points are earned
+ *
+ * @param  {RestClient}         client                          The REST client representing the user viewing the asset
+ * @param  {Course}             course                          The Canvas course in which the user is interacting with the API
+ * @param  {Number}             assetId                         The id of the viewed asset
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertViewAssetActivity = module.exports.assertViewAssetActivity = function(client, course, assetId, callback) {
+  // Get the points that are earned when viewing an asset
+  assertGetActivityTypeConfiguration(client, course, function(configuration) {
+    var viewPoints = _.findWhere(configuration, {'type': 'view_asset'}).points;
+
+    // Get the me object for the user viewing the asset
+    UsersTestUtil.assertGetMe(client, course, null, function(me) {
+      // View the asset
+      AssetsTestUtil.assertGetAsset(client, course, assetId, null, null, function(asset) {
+
+        // If viewer is among asset creators
+        if (_.find(asset.users, {'id': me.id})) {
+          // Points are not changed and last_activity timestamp is not updated
+            assertPoints(client, course, me, 0, false, callback);
+
+        // If viewer is not among asset creators
+        } else {
+          // If no points are allocated to asset view 
+          if (!viewPoints) {
+            // Points are not changed, but last_activity timestamp is updated
+            assertPoints(client, course, me, 0, true, callback);
+
+          // If points are allocated to asset view
+          } else {
+            // Points are changed and last_activity timestamp is updated
+            assertPoints(client, course, me, viewPoints, true, callback);
+          }
+        }
       });
     });
   });

--- a/node_modules/col-assets/lib/api.js
+++ b/node_modules/col-assets/lib/api.js
@@ -184,13 +184,14 @@ var getAsset = module.exports.getAsset = function(ctx, id, opts, callback) {
     });
 
     // Increment the number of views for the asset if specified
-    return incrementViewsIfRequired(asset, opts.incrementViews, callback);
+    return incrementViewsIfRequired(ctx, asset, opts.incrementViews, callback);
   });
 };
 
 /**
  * Increment the view count for an asset if required
  *
+ * @param  {Context}        ctx                     Standard context containing the current user and the current course
  * @param  {Asset}          asset                   The asset for which to increment the view count
  * @param  {Boolean}        incrementViews          Whether to increment the asset's view count or not
  * @param  {Function}       callback                Standard callback function
@@ -198,18 +199,34 @@ var getAsset = module.exports.getAsset = function(ctx, id, opts, callback) {
  * @param  {Object}         callback.asset          The updated asset
  * @api private
  */
-var incrementViewsIfRequired = function(asset, incrementViews, callback) {
+var incrementViewsIfRequired = function(ctx, asset, incrementViews, callback) {
   if (!incrementViews) {
     return callback(null, asset);
   }
 
   asset.increment('views').complete(function(err) {
     if (err) {
-      log.error({'err': err, 'id': id}, 'Failed to increase the views on an asset');
+      log.error({'err': err, 'id': asset.id}, 'Failed to increase the views on an asset');
       return callback({'code': 500, 'msg': err.message});
     }
 
-    return callback(null, asset);
+    // In the case of a user viewing their own asset, we use the same logic as comments. The total number
+    // of asset views is incremented, but we do not create a distinct view_asset activity (which could contribute
+    // to point totals).
+    var isAssetOwner = _.find(asset.users, {'id': ctx.user.id});
+    if (isAssetOwner) {
+      return callback(null, asset);
+
+    } else {
+      ActivitiesAPI.createActivity(ctx.course, ctx.user, 'view_asset', asset.id, CollabosphereConstants.ACTIVITY.OBJECT_TYPES.ASSET, null, null, function(err) {
+        if (err) {
+          log.error({'user': ctx.user, 'err': err}, 'Failed to create activity \'view_asset\' for user');
+          return callback(err);
+        }
+
+        return callback(null, asset);
+      });
+    }
   });
 };
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-395

Rounding out work done by @johncrossman. Following the logic for other activity types, no distinct activity is logged for a user viewing their own asset.

The integration tests, being integration tests, are sensitive to the appearance of this new activity type and needed some massaging. The `w=1` option is recommended for review.