### PR TITLE
COL-472 Move version number reporting to its own feed

### DIFF
--- a/node_modules/col-core/lib/api.js
+++ b/node_modules/col-core/lib/api.js
@@ -349,8 +349,7 @@ var initializeCanvasPoller = function() {
 var getStatus = module.exports.getStatus = function(callback) {
   // Indicate that the Node.js process is up
   var status = {
-    'app': true,
-    'version': appPackage.version
+    'app': true
   };
 
   // Check if a connection with the database can be made
@@ -382,4 +381,17 @@ var getStatus = module.exports.getStatus = function(callback) {
     fileStream.write('Collabosphere');
     fileStream.end();
   });
+};
+
+/**
+ * Get the current version number of the Collabosphere app.
+ *
+ * @param  {Function}      callback                Standard callback function
+ * @param  {Object}        callback.version        The current version number of the Collabosphere app
+ */
+var getVersion = module.exports.getVersion = function(callback) {
+  var version = {
+    'version': appPackage.version
+  };
+  return callback(version);
 };

--- a/node_modules/col-core/lib/rest.js
+++ b/node_modules/col-core/lib/rest.js
@@ -33,3 +33,12 @@ Collabosphere.appServer.get('/api/status', function(req, res) {
     return res.status(200).send(status);
   });
 });
+
+/*!
+ * Get the version number of the Collabosphere app
+ */
+Collabosphere.appServer.get('/api/version', function(req, res) {
+  Collabosphere.getVersion(function(version) {
+    return res.status(200).send(version);
+  });
+});

--- a/node_modules/col-core/tests/test-status.js
+++ b/node_modules/col-core/tests/test-status.js
@@ -38,9 +38,22 @@ describe('Status', function() {
       assert.ok(!err);
       assert.ok(status);
       assert.strictEqual(status.app, true);
-      assert.ok(/^\d+\.\d+\.\d+$/.test(status.version));
       assert.strictEqual(status.db, true);
       assert.strictEqual(status.tmp, true);
+
+      return callback();
+    });
+  });
+
+  /**
+   * Test that verifies that the Collabosphere version number is reported
+   */
+  it('reports Collabosphere version number', function(callback) {
+    var anonymousClient = TestsUtil.getAnonymousClient();
+    anonymousClient.core.getVersion(function(err, version, response) {
+      assert.ok(!err);
+      assert.ok(version);
+      assert.ok(/^\d+\.\d+\.\d+$/.test(version.version));
 
       return callback();
     });

--- a/node_modules/col-rest/lib/rest/core.js
+++ b/node_modules/col-rest/lib/rest/core.js
@@ -37,4 +37,16 @@ module.exports = function(client) {
   client.core.getStatus = function(callback) {
     client.request('/api/status', 'GET', null, null, callback);
   };
+
+  /**
+   * Get the version number of the Collabosphere app
+   *
+   * @param  {Function}       callback                        Standard callback function
+   * @param  {Object}         callback.body                   The JSON response from the REST API
+   * @param  {Response}       callback.response               The response object as returned by requestjs
+   * @see col-core/lib/rest.js for more information
+   */
+  client.core.getVersion = function(callback) {
+    client.request('/api/version', 'GET', null, null, callback);
+  };
 };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-472

For Nagios reasons, Ops prefers that the /api/status feed not be subject to regular change.