### PR TITLE
COL-397 Add radar chart to weekly email

### DIFF
--- a/email-templates/weekly/html.ejs
+++ b/email-templates/weekly/html.ejs
@@ -451,6 +451,79 @@ if (topAssets.views) {
           </td>
         </tr>
 
+        <% 
+        if (weekly.user.radarChartPath) { 
+        -%>
+
+        <tr>
+          <td>
+            <h4 class="section-header">
+              How you contributed this week
+            </h4>
+          </td>
+        </tr>
+        
+        <tr>
+          <td>
+            <table cellpadding="0" cellspacing="5" class="activity-container-table">
+              <tbody>
+                <tr>
+                  <td valign="top">
+                    <div class="radarchart-legend">
+                      <div class="radarchart-legend-line">
+                        <div class="radarchart-legend-you"></div>
+                        You
+                      </div>
+                      <div class="radarchart-legend-line">
+                        <div class="radarchart-legend-class-average"></div>
+                        Class average
+                      </div>
+                    </div>
+                  </td>
+                  <td class="centered">
+                    <div>Assets uploaded</div>
+                    <div class="radarchart-points">
+                      <%= weekly.user.pointsFromAssetsUploaded || 0 %> <%= weekly.user.pointsFromAssetsUploaded === 1 ? 'point' : 'points' %>
+                    </div>
+                  </td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td class="centered" valign="middle">
+                    <div>Collaborating on whiteboards</div>
+                    <div class="radarchart-points">
+                      <%= weekly.user.pointsFromWhiteboards || 0 %> <%= weekly.user.pointsFromWhiteboards === 1 ? 'point' : 'points' %>
+                    </div>
+                  </td>
+                  <td>
+                    <img class="radarchart-image" src="<%= baseCollabosphereUrl + weekly.user.radarChartPath %>">
+                  </td>
+                  <td class="centered" valign="middle">
+                    <div>Comments &amp; replying</div>
+                    <div class="radarchart-points">
+                      <%= weekly.user.pointsFromComments || 0 %> <%= weekly.user.pointsFromComments === 1 ? 'point' : 'points' %>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td></td>
+                  <td class="centered">
+                    <div>Liking assets</div>
+                    <div class="radarchart-points">
+                      <%= weekly.user.pointsFromLikes || 0 %> <%= weekly.user.pointsFromLikes === 1 ? 'point' : 'points' %>
+                    </div>
+                  </td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+
+        <% 
+        } 
+        -%>
+
         <tr>
           <td>
             <h4 class="section-header">

--- a/email-templates/weekly/style.scss
+++ b/email-templates/weekly/style.scss
@@ -164,6 +164,44 @@ td {
   vertical-align: top;
 }
 
+/*************************
+ ** HOW YOU CONTRIBUTED **
+ *************************/
+
+.radarchart-image {
+  height: 244px;
+  width: 244px;
+}
+
+.radarchart-legend {
+  background-color: #f2f2f2;
+  float: left;
+  padding: 5px;
+  text-align: left;
+}
+
+.radarchart-legend-class-average {
+  background-color: #ffc020;
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+}
+
+.radarchart-legend-line {
+  line-height: 1.6em;
+}
+
+.radarchart-legend-you {
+  background-color: #4080a0;
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+}
+
+.radarchart-points {
+  font-weight: 800;
+}
+
 /**************************
  ** YOUR ASSETS RECEIVED **
  **************************/

--- a/node_modules/col-activities/data/radarChart.js
+++ b/node_modules/col-activities/data/radarChart.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright ©2016. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var _ = require('lodash');
+var crypto = require('crypto');
+var fabric = require('fabric').fabric;
+var fs = require('fs');
+var moment = require('moment-timezone');
+var os = require('os');
+var path = require('path');
+var util = require('util');
+
+var CollabosphereConstants = require('col-core/lib/constants');
+
+var CHART_PADDING = 22;
+var CHART_RADIUS = 100;
+var DARK_GRAY = '#999';
+var LIGHT_GRAY = '#eee';
+
+/**
+ * Create a radar chart and export to PNG
+ *
+ * @api private
+ */
+var init = function() {
+  // Get the chart values from standard in
+  getChartValues(function(err, chartValues) {
+    if (err) {
+      exitWithError(err, 'Could not get chart values from stdin');
+    }
+
+    // Export chart as a PNG stream
+    generatePng(chartValues, function(err, data) {
+      if (err) {
+        exitWithError(err, 'Could not generate PNG data');
+      }
+
+      // Find or create a path under the Apache document root from which PNG files can be served
+      var documentRoot = process.env.DOCUMENT_ROOT;
+      if (!documentRoot) {
+        exitWithError(null, 'Could not get Apache document root');
+      }
+
+      var emailDir = path.join(documentRoot, 'assets', 'email');
+      fs.stat(emailDir, function(err, stat) {
+        if (err) {
+          if (err.code === 'ENOENT') {
+            fs.mkdirSync(emailDir);
+          } else {
+            exitWithError(err, 'Failed to get directory for email assets');
+          }
+        }
+
+        // Construct filenames using a millisecond timestamp signed with a nonce string
+        var date = moment().format('YYYYMMDDHHmmssSSS');
+        crypto.randomBytes(4, function(err, buffer) {
+          if (err) {
+            exitWithError(err, 'Could not get nonce string');
+          }
+
+          var nonce = buffer.toString('hex');
+          var filename = util.format('radarchart-%s-%s.png', date, nonce);
+          var imagePath = path.join(emailDir, filename);
+
+          fs.writeFile(imagePath, data, {'encoding': 'binary'}, function(err) {
+            if (err) {
+              exitWithError(err, 'Could not write the PNG radar chart to disk');
+            }
+
+            // Return the file path to the parent process over stdout
+            var returnPath = path.join('/', 'assets', 'email', filename);
+            process.stdout.write(returnPath);
+            process.exit(0);
+          });
+        });
+      });
+    });
+  });
+};
+
+/**
+ * Get chart values from the parent process over standard in
+ *
+ * @param  {Function}   callback                 Standard callback function
+ * @param  {Object}     callback.err             An error that occurred, if any
+ * @param  {Object[]}   callback.chartValues     The chart values that were passed in over standard in
+ * @api private
+ */
+var getChartValues = function(callback) {
+  // By default, the stdin stream is paused
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+
+  var data = '';
+  process.stdin.on('data', function(chunk) {
+    data += chunk.toString();
+    // A line break signals the end of the stream
+    if (data.indexOf('\n') !== -1) {
+      process.stdin.pause();
+
+      // Parse the collected chunks and return the chart values to the caller
+      var chartValues = [];
+      try {
+        chartValues = JSON.parse(data.split('\n')[0]);
+      } catch (err) {
+        return callback(err);
+      };
+
+      return callback(null, chartValues);
+    }
+  });
+};
+
+/**
+ * Generate radar chart and export to PNG stream
+ *
+ * @param  {Object}     chartValues                 The chart values that were passed in over standard in
+ * @param  {Object}     chartValues.user            Point set for a single user
+ * @param  {Object}     chartValues.courseAverage   Point set for per-course averages
+ * @param  {Function}   callback                    Standard callback function
+ * @param  {Object}     callback.err                An error that occurred, if any
+ * @param  {Buffer}     callback.buff               Buffered PNG data
+ * @api private
+ */
+var generatePng = function(chartValues, callback) {
+  initializeChartCanvas(function(canvas, origin) {
+    if (!canvas) {
+      return callback({'code': 500, 'msg': 'Could not generate canvas for radar chart'});
+    }
+
+    // Set scale based on maximum point value
+    var maximumPointValue = _.chain(chartValues)
+                             .map(_.values)
+                             .flatten()
+                             .max()
+                             .value();
+    var scale = CHART_RADIUS / maximumPointValue;
+
+    // Define colors 
+    var colorMap = {
+      'user': '#4080a0',
+      'courseAverage': '#ffc020'
+    };
+
+    _.each(chartValues, function(pointSet, key) {
+      // Adjust point values to scale
+      var scaledPoints = {};
+      _.each(CollabosphereConstants.ACTIVITY.POINT_CATEGORIES_FOR_NOTIFICATIONS, function(category) {
+        points = pointSet[category] || 0;
+        scaledPoints[category] = _.round(scale * points);
+      });
+
+      // Draw colored polygon
+      canvas.add(new fabric.Polygon(
+        [
+          {x: origin, y: origin - scaledPoints.pointsFromAssetsUploaded},   // Top corner
+          {x: origin + scaledPoints.pointsFromComments, y: origin},         // Right corner
+          {x: origin, y: origin + scaledPoints.pointsFromLikes},            // Bottom corner
+          {x: origin - scaledPoints.pointsFromWhiteboards, y: origin}       // Left corner
+        ], 
+        {
+          fill: colorMap[key],
+          opacity: 0.7
+        }
+      ));
+    });
+
+    // Render the canvas
+    canvas.renderAll();
+
+    // Convert the canvas to a PNG file and return the data
+    canvas.nodeCanvas.toBuffer(function(err, buff) {
+      if (err) {
+        return callback(err);
+      }
+
+      return callback(null, buff);
+    });
+  });
+};
+
+/**
+ * Initialize a Fabric canvas for the radar chart
+ *
+ * @param  {Function}   callback                 Standard callback function
+ * @param  {Canvas}     callback.canvas          The generated Fabric canvas
+ * @param  {Number}     callback.origin          The distance in pixels between chart origin and canvas edge
+ * @api private
+ */
+var initializeChartCanvas = function(callback) {
+  // Set dimensions
+  var chartIncrement = CHART_RADIUS / 5;
+  var origin = CHART_RADIUS + CHART_PADDING;
+  var canvasSize = origin * 2;
+
+  // Create canvas
+  var canvas = fabric.createCanvasForNode(canvasSize, canvasSize);
+
+  // For the sake of speed, don't render the canvas until all elements are added
+  canvas.renderOnAddRemove = false;
+
+  canvas.setBackgroundColor('white');
+
+  var addCircle = function(radius, fill) {
+    canvas.add(new fabric.Circle({
+      left: origin,
+      top: origin,
+      radius: radius,
+      fill: fill,
+      originX: 'center',
+      originY: 'center',
+      stroke: DARK_GRAY,
+      strokeWidth: 1
+    }));
+  };
+
+  var addLine = function(points) {
+    canvas.add(new fabric.Line(points, {
+      stroke: DARK_GRAY,
+      strokeWidth: 1
+    }));
+  };
+
+  // Draw outer, filled circle
+  addCircle(100, LIGHT_GRAY);
+
+  // Draw axis lines
+  addLine([origin, 0, origin, canvasSize]);
+  addLine([0, origin, canvasSize, origin]);
+
+  // Draw inner circles
+  _.times(4, function(index) {
+    addCircle((index + 1) * chartIncrement);
+  });
+
+  return callback(canvas, origin);
+};
+
+/**
+ * Log errors and exit
+ *
+ * @param  {Object}     [err]     The error object to log, if any
+ * @param  {String}      msg      Additional message to log
+ * @api private
+ */
+var exitWithError = function(err, msg) {
+  if (err) {
+    console.error(err);
+  }
+  console.error(msg);
+  process.exit(1);
+};
+
+// Initialize the script
+init();

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -27,6 +27,7 @@ var _ = require('lodash');
 var async = require('async');
 var config = require('config');
 var moment = require('moment-timezone');
+var spawn = require('child_process').spawn;
 
 var CollabosphereConstants = require('col-core/lib/constants');
 var CourseAPI = require('col-course');
@@ -133,6 +134,9 @@ var handleUser = function(course, activitySummary, user, callback) {
     return callback();
   }
 
+  // Parse out activity data specific to the course.
+  var courseData = activitySummary.course;
+
   // Parse out activity data specific to this user.
   var userData = activitySummary.users[user.id] || {};
   if (!_.isEmpty(userData)) {
@@ -146,17 +150,83 @@ var handleUser = function(course, activitySummary, user, callback) {
     }
   }
 
-  var subject = 'This week\'s activity in ' + (course.name || 'The Asset Library and Whiteboards');
-  var emailData = {
-    'weekly': {
-      'course': activitySummary.course,
-      'user': userData
+  // Generate radar chart from activity data.
+  generateRadarChart(courseData, userData, function(err, radarChartPath) { 
+    if (err) {
+      log.error({'course': course, 'user': user, 'err': err}, 'Could not generate radar chart for weekly email, will send email without chart');
+    } else {
+      userData.radarChartPath = radarChartPath;
     }
+
+    // Set email subject and data to feed into the template.
+    var subject = 'This week\'s activity in ' + (course.name || 'The Asset Library and Whiteboards');
+    var emailData = {
+      'weekly': {
+        'course': courseData,
+        'user': userData
+      }
+    };
+
+    EmailUtil.sendEmail(subject, user, course, emailData, 'weekly', function(err) {
+      // Errors are logged in the sendEmail implementation. Ignore them here, and continue to the next user.
+      return callback();
+    });
+  });
+};
+
+/**
+ * Generate a radar chart from activity data as an addressable PNG
+ *
+ * @param  {Object}     courseData                 Weekly activity data for the course
+ * @param  {Object}     userData                   Weekly activity data for the user
+ * @param  {Function}   callback                   Standard callback function
+ * @param  {Object}     callback.err               An error that occurred, if any
+ * @param  {Buffer}     callback.radarChartPath    Path for the generated PNG chart
+ * @api private
+ **/
+var generateRadarChart = function(courseData, userData, callback) {
+  // To avoid blocking Node's event loop, spawn a child process to generate PNG radar charts
+  var childProcess = null;
+  try {
+    childProcess = spawn('node', ['../../data/radarChart.js'], {
+      'cwd': __dirname,
+      'env': process.env
+    });
+  } catch (err) {
+    log.error({'err': err}, 'Could not spawn a radarChart child process');
+    return callback(err);
+  }
+
+  // Send chart values to the child process over stdin
+  var chartValues = {
+    'user': _.pick(userData, CollabosphereConstants.ACTIVITY.POINT_CATEGORIES_FOR_NOTIFICATIONS),
+    'courseAverage': _.pick(courseData.averages, CollabosphereConstants.ACTIVITY.POINT_CATEGORIES_FOR_NOTIFICATIONS)
   };
 
-  EmailUtil.sendEmail(subject, user, course, emailData, 'weekly', function(err) {
-    // Errors are logged in the sendEmail implementation. Ignore them here, and continue to the next user.
-    return callback();
+  chartValues = JSON.stringify(chartValues);
+  childProcess.stdin.setEncoding = 'utf-8';
+  childProcess.stdin.write(chartValues);
+  childProcess.stdin.write('\n');
+
+  // Listen for response
+  var radarChartPath = null;
+  childProcess.stdout.on('data', function(data) {
+    radarChartPath = data.toString('utf8');
+  });
+
+  // Log any error message the child process generates
+  childProcess.stderr.on('data', function(data) {
+    log.error({'data': data.toString('utf-8')}, 'The radarChart script reported an error');
+  });
+
+  // Once the PNG has been generated or the script fails, return to the caller
+  childProcess.on('close', function(code) {
+    if (code !== 0) {
+      log.error({'code': code}, 'The radarChart script exited with an unexpected error code');
+      return callback({'code': 500, 'msg': 'Failed to generate a radar chart'});
+    }
+
+    return callback(null, radarChartPath);
   });
 };
 

--- a/node_modules/col-core/lib/constants.js
+++ b/node_modules/col-core/lib/constants.js
@@ -32,7 +32,8 @@ var Constants = module.exports = {
       'CHAT': 'chat',
       'COMMENT': 'comment',
       'WHITEBOARD': 'whiteboard'
-    }
+    },
+    'POINT_CATEGORIES_FOR_NOTIFICATIONS': ['pointsFromAssetsUploaded', 'pointsFromComments', 'pointsFromLikes', 'pointsFromWhiteboards']
   },
   'ADMIN_ROLES': ['urn:lti:instrole:ims/lis/Administrator'],
   'TEACHER_ROLES': ['ContentDeveloper', 'Instructor', 'urn:lti:role:ims/lis/TeachingAssistant'],


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-397

We generate one chart per user per week, and for the moment are simply storing them as PNG files on disk in a directory accessible to Apache. Generated files are between 17-20 kB; a script to delete older files after a certain point might be an advisable follow-up.