### PR TITLE
COL-444 Schedule weekly email on app startup

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -41,8 +41,8 @@
   "email": {
     "enabled": true,
     "dailyHour": 8,
-    "weeklyDay": 5,
-    "weeklyHour": 12,
+    "weeklyDay": 1,
+    "weeklyHour": 9,
     "apiKey": "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"
   }
 }

--- a/node_modules/col-activities/lib/api.js
+++ b/node_modules/col-activities/lib/api.js
@@ -38,15 +38,16 @@ var UserConstants = require('col-users/lib/constants');
 
 var ActivitiesDefaults = require('./default');
 var DailyNotifications = require('./notifications/daily');
+var WeeklyNotifications = require('./notifications/weekly');
 
 /* Notifications */
 
 /**
- * Schedule the collection of the email notifications
+ * Schedule the collection of daily email notifications
  *
  * @api private
  */
-var scheduleCollect = function() {
+var scheduleDaily = function() {
   // When the emails should go out. For now, we're just using the server's timezone
   var hour = config.get('email.dailyHour');
 
@@ -61,11 +62,36 @@ var scheduleCollect = function() {
 
   var diff = emailMoment.diff(now);
   log.info('Scheduling daily notifications for %s (in %d ms)', emailMoment.format(), diff);
-  setTimeout(DailyNotifications.collect, diff, scheduleCollect);
+  setTimeout(DailyNotifications.collect, diff, scheduleDaily);
 };
 
-scheduleCollect();
+scheduleDaily();
 
+/**
+ * Schedule the collection of weekly email notifications
+ *
+ * @api private
+ */
+var scheduleWeekly = function() {
+  // When the emails should go out. For now, we're just using the server's timezone
+  var day = config.get('email.weeklyDay');
+  var hour = config.get('email.weeklyHour');
+
+  // Figure out the exact moment when to send out the emails
+  var emailMoment = moment().minutes(0).seconds(0);
+  var now = moment();
+  if (now.day() < day || (now.day() === day && now.hours() < hour)) {
+    emailMoment = emailMoment.day(day).hours(hour);
+  } else {
+    emailMoment = emailMoment.add(1, 'week').day(day).hours(hour);
+  }
+
+  var diff = emailMoment.diff(now);
+  log.info('Scheduling weekly notifications for %s (in %d ms)', emailMoment.format(), diff);
+  setTimeout(WeeklyNotifications.collect, diff, scheduleWeekly);
+};
+
+scheduleWeekly();
 
 /* Activities */
 

--- a/node_modules/col-activities/lib/notifications/weekly.js
+++ b/node_modules/col-activities/lib/notifications/weekly.js
@@ -77,6 +77,12 @@ var sendWeeklyNotificationsForCourse = module.exports.sendWeeklyNotificationsFor
     return callback({'code': 401, 'msg': 'Unauthorized to send weekly notifications for a course'});
   }
 
+  // Do not send the email unless asset library and engagement index are both enabled
+  if (!ctx.course.assetlibrary_url || !ctx.course.engagementindex_url) {
+    log.info({'course': ctx.course}, 'Skipping weekly notification email for course without enabled tools');
+    return callback();
+  }
+
   return collectCourse(ctx.course, callback);
 };
 

--- a/node_modules/col-activities/tests/test-weekly.js
+++ b/node_modules/col-activities/tests/test-weekly.js
@@ -48,17 +48,35 @@ describe('Weekly activity emails', function() {
   });
 
   /**
-   * Test that verifies that emails are sent to active users in a course
+   * Test that verifies that emails are sent to active users in a course with tools enabled
    */
-  it('sends emails to all active users in a course', function(callback) {
+  it('sends emails to all active users in a course with tools enabled', function(callback) {
     ActivitiesTestUtil.setupCourseWithInstructor(function(dbCourse, course, users, instructor) {
       var userObjects = _.map(users, function(user) { 
         return user.me; 
       });
 
-      // Verify that everyone gets an email
-      ActivitiesTestUtil.assertSendWeeklyNotifications(users.instructor.client, course, dbCourse, userObjects, function(emails) {
-        return callback();
+      // Verify that no one gets an email before LTI tools are initialized
+      ActivitiesTestUtil.assertSendWeeklyNotificationsEmpty(users.instructor.client, course, dbCourse, userObjects, function() {
+
+        // Initialize asset library but not engagement index
+        dbCourse.assetlibrary_url = 'http://bcourses.berkeley.edu/courses/1/external_tools/1';
+
+        dbCourse.save().complete(function(err, dbCourse) {
+          // Verify that, once again, no one gets an email
+          ActivitiesTestUtil.assertSendWeeklyNotificationsEmpty(users.instructor.client, course, dbCourse, userObjects, function() {
+
+            // Initialize engagement index
+            dbCourse.engagementindex_url = 'http://bcourses.berkeley.edu/courses/1/external_tools/2';
+            dbCourse.save().complete(function(err, dbCourse) {
+
+              // Verify that everyone gets an email
+              ActivitiesTestUtil.assertSendWeeklyNotifications(users.instructor.client, course, dbCourse, userObjects, function(emails) {
+                return callback();
+              });
+            });
+          });
+        });
       });
     });
   });

--- a/node_modules/col-activities/tests/util.js
+++ b/node_modules/col-activities/tests/util.js
@@ -892,6 +892,40 @@ var assertEmailsForUsers = function(emails, users) {
 };
 
 /**
+ * Assert that a request to send weekly notification emails passes authorization but sends no messages
+ *
+ * @param  {RestClient}          client                           The REST client to make the request with
+ * @param  {Course}              course                           The Canvas course in which the user is interacting with the API
+ * @param  {Course}              dbCourse                         The database model for the course
+ * @param  {User[]}              users                            The users who should receive an email
+ * @param  {Function}            callback                         Standard callback function
+ * @param  {Object[]}            callback.emails                  The sent email messages
+ * @throws {AssertionError}                                       Error thrown when an assertion fails
+ */
+var assertSendWeeklyNotificationsEmpty = module.exports.assertSendWeeklyNotificationsEmpty = function(client, course, dbCourse, users, callback) {
+  // Collect any emails that are sent out when collecting the weekly notifications
+  var emails = [];
+  function emailListener(email, user, dbCourse) {
+    emails.push({
+      'email': email,
+      'user': user,
+      'course': dbCourse
+    });
+  };
+  EmailUtil.on(EmailUtil.EVENT_NAMES.EMAIL_SENT, emailListener);
+
+  client.activities.sendWeeklyNotificationsForCourse(course, function(err, response) {
+    assert.ok(!err);
+    assert.ok(response);
+
+    EmailUtil.removeListener(EmailUtil.EVENT_NAMES.EMAIL_SENT, emailListener);
+    assert.ok(!emails.length);
+
+    return callback();
+  });
+};
+
+/**
  * Assert that the weekly notification email for a course can not be manually triggered
  *
  * @param  {RestClient}         client                            The REST client to make the request with


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-444

Per user request, weekly emails are set to Monday morning by default.

Includes a second commit to skip the weekly email for courses where the asset library or engagement index is not enabled.