### PR TITLE
COL-499 Add fallbacks for Canvas instances without custom cross-window messaging

### DIFF
--- a/apache/collabosphere.template
+++ b/apache/collabosphere.template
@@ -55,8 +55,8 @@
         ExpiresDefault "access plus 1 year"
     </LocationMatch>
 
-    # Don't cache the root HTML pages or the bookmarklet init script
-    <LocationMatch "^(/assets/js/bookmarklet-init.js|/bookmarklet.html)">
+    # Don't cache the root HTML pages or public scripts
+    <LocationMatch "^(/assets/js/|/bookmarklet.html)">
         <IfModule mod_headers.c>
              Header unset ETag
              Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,6 +77,14 @@ gulp.task('copyBookmarkletFiles', function() {
 });
 
 /**
+ * Copy Canvas customization code. Do not version or minify, since this code serves as a public reference.
+ */
+gulp.task('copyCanvasCustomization', function() {
+  return gulp.src('public/assets/js/canvas-customization.js', {'base': 'public'})
+    .pipe(gulp.dest('target'));
+});
+
+/**
  * Copy the bookmarklet dependencies to the build directory
  */
 gulp.task('minifyBookmarkletFiles', ['copyBookmarkletFiles'], function() {
@@ -227,7 +235,7 @@ gulp.task('replaceImages', ['optimizeImages'], function() {
  * Create a build
  */
 gulp.task('build', function() {
-  return runSequence('clean', ['replaceBookmarkletDependencies', 'copyFonts', 'minify'], 'replaceImages', 'minifyViewer', 'copyViewerAssets');
+  return runSequence('clean', ['replaceBookmarkletDependencies', 'copyFonts', 'minify'], 'copyCanvasCustomization', 'replaceImages', 'minifyViewer', 'copyViewerAssets');
 });
 
 /**

--- a/node_modules/col-core/lib/db.js
+++ b/node_modules/col-core/lib/db.js
@@ -126,13 +126,14 @@ var setUpModel = function(sequelize) {
    * communicate with. It holds all the information that's needed to interact with the
    * Canvas API and to embed the Collabosphere tools into Canvas
    *
-   * @property  {String}      canvas_api_domain       The domain on which Canvas is running
-   * @property  {String}      api_key                 The key that can be used to interact with the Canvas API
-   * @property  {String}      lti_key                 The basic LTI key that will be used to embed the tools into Canvas
-   * @property  {String}      lti_secret              The basic LTI secret that will be used to embed the tools into Canvas
-   * @property  {Boolean}     use_https               Whether the Canvas API is running on https
-   * @property  {String}      name                    The name of the service that is running on Canvas (e.g., bCourses)
-   * @property  {String}      logo                    A URL to the logo of the service that is running on Canvas (e.g., a URL to the bCourses logo)
+   * @property  {String}      canvas_api_domain           The domain on which Canvas is running
+   * @property  {String}      api_key                     The key that can be used to interact with the Canvas API
+   * @property  {String}      lti_key                     The basic LTI key that will be used to embed the tools into Canvas
+   * @property  {String}      lti_secret                  The basic LTI secret that will be used to embed the tools into Canvas
+   * @property  {Boolean}     use_https                   Whether the Canvas API is running on https
+   * @property  {String}      name                        The name of the service that is running on Canvas (e.g., bCourses)
+   * @property  {String}      logo                        A URL to the logo of the service that is running on Canvas (e.g., a URL to the bCourses logo)
+   * @property  {Boolean}     supports_custom_messaging   Whether the Canvas instance supports our customized cross-window messaging
    */
   var Canvas = module.exports.Canvas = sequelize.define('canvas', {
     'canvas_api_domain': {
@@ -165,6 +166,10 @@ var setUpModel = function(sequelize) {
     'logo': {
       'type': Sequelize.STRING,
       'allowNull': true
+    },
+    'supports_custom_messaging' : {
+      'type': Sequelize.BOOLEAN,
+      'defaultValue': false
     }
   }, {
     'tableName': 'canvas',

--- a/node_modules/col-lti/lib/api.js
+++ b/node_modules/col-lti/lib/api.js
@@ -151,6 +151,9 @@ var launch = module.exports.launch = function(req, toolId, callback) {
           // Keep track of the URL that is performing the LTI launch
           provider.body.tool_url = req.headers.referer;
 
+          // Keep track of whether this Canvas instance supports custom cross-window messaging
+          provider.body.supports_custom_messaging = canvas.supports_custom_messaging;
+
           return callback(null, provider.body, user);
         });
       });

--- a/node_modules/col-lti/lib/rest.js
+++ b/node_modules/col-lti/lib/rest.js
@@ -66,6 +66,12 @@ var launch = function(req, res, toolId) {
     var name = encodeURIComponent(api_domain + '_' + course_id);
     res.cookie(name, user.id, {'signed': true});
 
+    // Store another cookie to let the application know whether this Canvas instance supports customized
+    // cross-window messaging.
+    var customMessagingCookieName = encodeURIComponent(body.custom_canvas_api_domain + '_supports_custom_messaging');
+    var customMessagingCookieValue = encodeURIComponent(body.supports_custom_messaging);
+    res.cookie(customMessagingCookieName, customMessagingCookieValue);
+
     // Redirect the user to the tool's HTML. We need to include the api_domain
     // and course id so the application can bootstrap itself
     var url = '/' + toolId;

--- a/public/app/assetlibrary/item/assetLibraryItemController.js
+++ b/public/app/assetlibrary/item/assetLibraryItemController.js
@@ -58,6 +58,8 @@
     });
 
     // Add the asset id to the parent container's to allow for deep linking to the asset
+    // NOTE: For deep linking to work, our custom 'getParentUrlData' and 'setParentHash' cross-window events must be supported
+    // in the hosting Canvas instance.
     utilService.setParentHash({'asset': assetId});
 
     /**
@@ -299,6 +301,8 @@
      * Restore the asset library search options when navigating back to the asset library list. As navigating
      * back to the asset library list doesn't trigger a new search, the easiest solution is to restore the hash
      * value here
+     * NOTE: This functionality requires our custom 'getParentUrlData' and 'setParentHash' cross-window events to be
+     * supported in the hosting Canvas instance.
      */
     var backToAssetLibrary = $scope.backToAssetLibrary = function() {
       utilService.setParentHash($scope.$parent.searchOptions);

--- a/public/app/assetlibrary/list/assetLibraryListController.js
+++ b/public/app/assetlibrary/list/assetLibraryListController.js
@@ -76,6 +76,8 @@
     var getAssets = $scope.getAssets = function() {
       // Keep track of the search options in the parent container's hash to allow
       // for deep linking to a search
+      // NOTE: For deep linking to work, our custom 'getParentUrlData' and 'setParentHash' cross-window events must be supported
+      // in the hosting Canvas instance.
       utilService.setParentHash($scope.searchOptions);
 
       // Indicate that no further REST API requests should be made
@@ -117,6 +119,7 @@
         // Resize the iFrame the Asset Library is being run in
         utilService.resizeIFrame();
         // Restore the scroll position to the position the list was in previously
+        // NOTE: This functionality requires our custom 'scrollTo' event to be supported in the hosting Canvas instance.
         utilService.scrollTo(scrollPosition);
         // Indicate that more results can be loaded
         $scope.list.ready = true;

--- a/public/app/whiteboards/list/whiteboardsListController.js
+++ b/public/app/whiteboards/list/whiteboardsListController.js
@@ -71,7 +71,8 @@
     $scope.popupBlocked = false;
     $scope.deepLinkedWhiteboard = {};
 
-    // Check whether a whiteboard was deep linked (from an email or the syllabus)
+    // Check whether a whiteboard was deep linked (from an email or the syllabus).
+    // NOTE: Deep linking to whiteboards requires our custom 'getParentUrlData' event in the hosting Canvas instance.
     if (window.parent) {
       utilService.getParentUrlData(function(data) {
         if (data.whiteboard) {

--- a/public/assets/js/canvas-customization.js
+++ b/public/assets/js/canvas-customization.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright ©2016. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+/**
+ * For the best experience using the SuiteC tools, the customization code below should be added to Canvas.
+ * This code allows the tools to adjust the height and scrolling of the parent frame, and to
+ * access the parent frame's address bar. This enables:
+ *  - A better experience scrolling lengthy lists and viewing large assets;
+ *  - Direct links to individual assets and whiteboards;
+ *  - Direct links to prepopulated asset and whiteboard searches.
+ */
+
+(function(window, document, $) {
+  'use strict';
+
+  /**
+   * We use window events to interact between the LTI iframe and the parent container.
+   * Resizing the iframe based on its content is handled by Instructure's `public/javascripts/tool_inline.js`
+   * file, and it determines the message format we use.
+   *
+   * The following custom events are provided for modifying the URL of the parent container:
+   *
+   *  - Change the location of the parent container:
+   *    ```
+   *     {
+   *       subject: 'changeParent',
+   *       parentLocation: <newLocation>
+   *     }
+   *    ```
+   *
+   *  - Change the hash of the parent container:
+   *    ```
+   *     {
+   *       subject: 'setParentHash',
+   *       'hash': <newHash>
+   *     }
+   *    ```
+   *
+   * The following custom event is provided to retrieve the URL of the parent container:
+   *
+   *  - Get the location of the parent container:
+   *    ```
+   *     {
+   *       subject: 'getParent'
+   *     }
+   *    ```
+   *
+   * The following custom events are provided to support scrolling-related interaction between
+   * the LTI iFrame and the parent container:
+   *
+   *  - Change the height of the LTI iFrame:
+   *    ```
+   *     {
+   *       subject: 'changeParent',
+   *       height: <height>
+   *     }
+   *    ```
+   *
+   *  - Scroll the parent container to a specified position:
+   *    ```
+   *     {
+   *       subject: 'changeParent',
+   *       scrollTo: <scrollPosition>
+   *     }
+   *    ```
+   *
+   *  - Scroll the parent container to the top of the screen:
+   *    ```
+   *     {
+   *       subject: 'changeParent',
+   *       scrollToTop: true
+   *     }
+   *    ```
+   *
+   *  - Get the scroll information of the parent container:
+   *    ```
+   *     {
+   *       subject: 'getScrollInformation'
+   *     }
+   *    ```
+   *
+   *    Each of these events will respond with a window event back to the LTI iframe containing the scroll information
+   *    for the parent container:
+   *    ```
+   *     {
+   *       iFrameHeight: <currentIframeHeight>,
+   *       parentHeight: <currentParentHeight>,
+   *       scrollPosition: <currentScrollPosition>,
+   *       scrollToBottom: <currentHeightBelowFold>
+   *     }
+   *    ```
+   *
+   * @param  {Object}    ev         Event that is sent over from the iframe
+   * @param  {String}    ev.data    The message sent with the event. Note that this is expected to be a stringified JSON object
+   */
+  window.onmessage = function(ev) {
+    // Parse the provided event message
+    if (ev && ev.data) {
+      var message;
+      try {
+        message = JSON.parse(ev.data);
+      } catch (err) {
+        // The message is not for us; ignore it
+        return;
+      }
+
+      var response = null;
+      // Event that will modify the URL of the parent container
+      if (message.subject === 'changeParent' && message.parentLocation) {
+        window.location = message.parentLocation;
+
+      // Event that retrieves the parent container's URL
+      } else if (message.subject === 'getParent') {
+        response = {
+          'location': window.location.href
+        };
+        ev.source.postMessage(JSON.stringify(response), '*');
+
+      // Event that will modify the hash of the parent container's URL
+      } else if (message.subject === 'setParentHash') {
+        history.replaceState(undefined, undefined, '#' + message.hash);
+
+      // Events related to scrolling interaction between the LTI iFrame and the parent container
+      } else if (message.subject === 'changeParent' || message.subject === 'getScrollInformation') {
+        // Scroll to the specified position
+        if (message.scrollTo !== undefined) {
+          window.scrollTo(0, message.scrollTo);
+        // Scroll to the top of the current window
+        } else if (message.scrollToTop) {
+          window.scrollTo(0, 0);
+        } else if (message.height !== undefined) {
+          if (!message.height || message.height < 450) {
+            message.height = 450;
+          }
+          $('.tool_content_wrapper').height(message.height).data('height_overridden', true);
+        }
+
+        // Respond with a window event back to the LTI iframe containing the scroll information for the parent container
+        if (ev.source) {
+          var iFrameHeight = $('.tool_content_wrapper').height();
+          var parentHeight = $(document).height();
+          var scrollPosition = $(document).scrollTop();
+          var scrollToBottom = parentHeight - $(window).height() - scrollPosition;
+          response = {
+            'iFrameHeight': iFrameHeight,
+            'parentHeight': parentHeight,
+            'scrollPosition': scrollPosition,
+            'scrollToBottom': scrollToBottom
+          };
+          ev.source.postMessage(JSON.stringify(response), '*');
+        }
+      }
+    }
+  };
+
+})(window, window.document, window.$);

--- a/scripts/20161003-col499/add_canvas_supports_custom_messaging.sql
+++ b/scripts/20161003-col499/add_canvas_supports_custom_messaging.sql
@@ -1,0 +1,3 @@
+-- Add a per-Canvas column specifying whether the Canvas instance supports our custom cross-window messaging.
+
+ALTER TABLE canvas ADD supports_custom_messaging boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-499

Core SuiteC features, including tool resizing, scrolling and deeplinks, are dependent on custom cross-window messages, support for which must be added to the hosting Canvas instance. Where possible, add fallbacks when this support is not present. In all cases, make the dependency more explicit. 
- The 'canvas' table is altered to specify whether a Canvas instance supports custom messaging.
- This information is made available to the front end through a cookie on LTI launch. If custom messages are not supported, the front end should not send them.
- Fallbacks for scrolling and tool resizing are implemented.
- A fallback for deep links is out of scope for this PR. The lack of functionality is documented.
- Relevant Canvas customization code is extracted from the CalCentral repository and documented in comments.