### PR TITLE
COL-473 Award EI points for multiple postings to a topic

### DIFF
--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -884,7 +884,10 @@ var createDiscussionEntryActivity = function(ctx, activities, users, discussion,
     'type': 'discussion_entry',
     'objectId': discussion.id,
     'objectType': CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_DISCUSSION,
-    'user': entry.user_id
+    'user': entry.user_id,
+    'metadata': {
+      'entryId': entry.id
+    }
   };
   getOrCreateActivity(ctx, activities, users, activity, callback);
 };
@@ -913,7 +916,10 @@ var handleDiscussionEntryReply = function(ctx, activities, users, discussion, en
     'type': 'discussion_entry',
     'objectId': discussion.id,
     'objectType': CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_DISCUSSION,
-    'user': reply.user_id
+    'user': reply.user_id,
+    'metadata': {
+      'entryId': entry.id
+    }
   };
   getOrCreateActivity(ctx, activities, users, activity, function(err) {
     if (err) {
@@ -926,7 +932,10 @@ var handleDiscussionEntryReply = function(ctx, activities, users, discussion, en
       'objectId': discussion.id,
       'objectType': CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_DISCUSSION,
       'user': entry.user_id,
-      'actor': reply.user_id
+      'actor': reply.user_id,
+      'metadata': {
+        'entryId': entry.id
+      }
     };
     return getOrCreateActivity(ctx, activities, users, activity, callback);
   });
@@ -952,14 +961,21 @@ var getActivities = function(ctx, type, objectId, objectType, callback) {
       return callback(err);
     }
 
-    // Index the activities on their Canvas user id, activity type and object id. This allows
+    // Index the activities on their Canvas user id, activity type and activity key. This allows
     // for quickly checking whether an activity has already been tracked
     var indexedActivities = {};
     _.each(activities, function(activity) {
+      // Most activities are tracked by object ID; discussion entries are tracked by the combination of object ID and entry ID.
+      var activityKey = null;
+      if ((activity.type === 'discussion_entry') || (activity.type === 'get_discussion_entry_reply')) {
+        activityKey = activity.object_id + '_' + activity.metadata.entryId;
+      } else {
+        activityKey = activity.object_id;
+      }
       var canvasUserId = activity.user.canvas_user_id;
       indexedActivities[canvasUserId] = indexedActivities[canvasUserId] || {};
       indexedActivities[canvasUserId][activity.type] = indexedActivities[canvasUserId][activity.type] || {};
-      indexedActivities[canvasUserId][activity.type][activity.object_id] = activity;
+      indexedActivities[canvasUserId][activity.type][activityKey] = activity;
     });
 
     return callback(null, indexedActivities);
@@ -986,8 +1002,15 @@ var getActivities = function(ctx, type, objectId, objectType, callback) {
  * @api private
  */
 var getOrCreateActivity = function(ctx, activities, users, activity, callback) {
-  // Don't create an activity if we've already done so
-  var existingActivity = getActivity(activities, activity.user, activity.type, activity.objectId);
+  // Don't create an activity if we've already done so. Most activities are tracked by object ID; discussion entries are tracked 
+  // by the combination of object ID and entry ID.
+  var activityKey = null;
+  if ((activity.type === 'discussion_entry') || (activity.type === 'get_discussion_entry_reply')) {
+    activityKey = activity.objectId + '_' + activity.metadata.entryId;
+  } else {
+    activityKey = activity.objectId;
+  }
+  var existingActivity = getActivity(activities, activity.user, activity.type, activityKey);
   if (existingActivity) {
     return callback(null, existingActivity, false);
   }
@@ -1027,16 +1050,17 @@ var getOrCreateActivity = function(ctx, activities, users, activity, callback) {
 /**
  * Check whether an activity can be found in a set of indexed activities
  *
- * @param  {Object}       indexedActivities       A set of activities as returned by `getActivities`
- * @param  {Number}       canvasUserId            The Canvas id of the user who triggered the activity
- * @param  {String}       type                    The activity type
- * @param  {String}       objectId                The id of the object on which the activity is taking place (e.g., the asset id, the comment id, etc.)
- * @return {Activity}                             The activity if it could be found in the set of indexed activities, `null` otherwise
+ * @param  {Object}       indexedActivities     A set of activities as returned by `getActivities`
+ * @param  {Number}       canvasUserId          The Canvas id of the user who triggered the activity
+ * @param  {String}       type                  The activity type
+ * @param  {String}       activityKey           The key under which the activity is indexed - either the id of the object on which the activity
+ *                                              is taking place (e.g., asset id, comment id), or a combination of such ids.
+ * @return {Activity}                           The activity if it could be found in the set of indexed activities, `null` otherwise
  * @api private
  */
-var getActivity = function(indexedActivities, canvasUserId, type, objectId) {
-  if (indexedActivities[canvasUserId] && indexedActivities[canvasUserId][type] && indexedActivities[canvasUserId][type][objectId]) {
-    return indexedActivities[canvasUserId][type][objectId];
+var getActivity = function(indexedActivities, canvasUserId, type, activityKey) {
+  if (indexedActivities[canvasUserId] && indexedActivities[canvasUserId][type] && indexedActivities[canvasUserId][type][activityKey]) {
+    return indexedActivities[canvasUserId][type][activityKey];
   } else {
     return null;
   }

--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -1220,7 +1220,19 @@ describe('Canvas poller', function() {
                                       assert.strictEqual(getUserByName(users, user1.fullName).points, topicPoints);
                                       assert.strictEqual(getUserByName(users, user2.fullName).points, entryPoints + entryGetReplyPoints);
                                       assert.strictEqual(getUserByName(users, user3.fullName).points, entryPoints);
-                                      return callback();
+
+                                      // User 2, who made the previous entry, makes another entry on the same topic.
+                                      discussion.addEntry(new CanvasDiscussionEntry(user2));
+                                      CanvasTestsUtil.mockPollingRequests(dbCourse, mockedUsers, [], [discussion]);
+                                      CanvasPoller.handleCourse(dbCourse, null, function(err) {
+                                        assert.ok(!err);
+
+                                        // User 2 should get additional points for the second entry.
+                                        UsersTestUtil.assertGetLeaderboard(client1, course, 3, false, function(users) {
+                                          assert.strictEqual(getUserByName(users, user2.fullName).points, (entryPoints * 2) + entryGetReplyPoints);
+                                          return callback();
+                                        });
+                                      });
                                     });
                                   });
                                 });

--- a/scripts/20161109-col517/remove_old_discussion_activities.js
+++ b/scripts/20161109-col517/remove_old_discussion_activities.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright ©2016. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+var _ = require('lodash');
+var async = require('async');
+var config = require('config');
+
+var ActivitiesAPI = require('col-activities');
+var CollabosphereConstants = require('col-core/lib/constants');
+var DB = require('col-core/lib/db');
+var log = require('col-core/lib/logger')('scripts/20161011-col509/remove_old_discussion_activities');
+
+var init = function() {
+  // Apply global utilities.
+  require('col-core/lib/globals');
+
+  // Connect to the database.
+  DB.init(function(err) {
+    if (err) {
+      return log.error({'err': err}, 'Unable to set up a connection to the database');
+    }
+    log.info('Connected to the database');
+
+    removeOldActivities();
+  });
+};
+
+var removeOldActivities = function() {
+  // Get all discussion activities.
+  var options = {
+    'where': {
+      'type': ['discussion_entry', 'get_discussion_entry_reply'],
+      'object_type': CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_DISCUSSION
+    }
+  };
+
+  DB.Activity.findAll(options).complete(function(err, activities) {
+    if (err) {
+      log.error({'err': err}, 'Failed to retrieve activities');
+      return;
+    }
+
+    var removed = 0;
+    var notRemoved = 0;
+    var errored = 0;
+
+    async.eachSeries(activities, function(activity, done) {
+      // Old discussion activities are those without an entryId. Activities with an entryId should be skipped.
+      if (activity.metadata.entryId) {
+        notRemoved++;
+        return done();
+      }
+
+      activity.getUser().complete(function(err, user) {
+        if (err) {
+          log.error({'err': err}, 'Failed to get user for activity ' + activity.id + ', skipping.');
+          errored++;
+          return done();
+        }
+
+        // Retrieve the number of points that should be deducted from the user's total.
+        ActivitiesAPI.getActivityTypeConfiguration(activity.course_id, function(err, configuration) {
+          if (err) {
+            log.error({'err': err}, 'Failed to get configuration for activity ' + activity.id + ', skipping.');
+            errored++;
+            return done();
+          }
+
+          // Deduct the points.
+          var points = _.find(configuration, {'type': activity.type}).points;
+          user.decrement('points', {'by': points}).complete(function(err) {
+            if (err) {
+              log.error({'err': err}, 'Failed to decrement user points for activity ' + activity.id + ', skipping.');
+              errored++;
+              return done();
+            }
+
+            // Delete the activity.
+            var id = activity.id;
+            activity.destroy().complete(function(err) {
+              if (err) {
+                log.error({'err': err, 'activity': activity}, 'Failed to delete activity ' + activity.id);
+                errored++;
+              } else {
+                log.info('Delete activity ' + id); 
+                removed++;
+              }
+              return done();
+            });
+          });
+        });
+      });
+    }, function(err, results) { 
+      if (err) {
+        log.error({'err': err}, 'Failed to remove activities');
+      } else {
+        log.info('Finished. Removed ' + removed + ' activities; kept ' + notRemoved + ' activities; ' + errored + ' errors.');
+      }
+    });
+  });
+};
+
+init();


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-473

Once this new logic is in place, the poller should gamely sweep through and pick up older discussion activities in the new format. Discussion activities in the old format will appear as duplicates. The migration script to remove those duplicates should be run post-release, once we've confirmed that the new poller logic is working as expected.