### PR TITLE
COL-458 Make Canvas assignment categories invisible

### DIFF
--- a/scripts/20160910-col398/add_category_visible.sql
+++ b/scripts/20160910-col398/add_category_visible.sql
@@ -2,3 +2,7 @@
 -- should be displaying in the Asset Library
 
 ALTER TABLE categories ADD visible BOOLEAN NOT NULL DEFAULT true;
+
+-- Categories derived from Canvas assignments should be invisible by default.
+
+UPDATE categories SET visible = false WHERE canvas_assignment_id IS NOT NULL;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-458

Migrations to adjust database structure are already in place. This addition ensures that categories derived from assignments start out invisible.