### PR TITLE
COL-473 Track discussion replies by reply ID, not parent entry ID

### DIFF
--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -918,7 +918,7 @@ var handleDiscussionEntryReply = function(ctx, activities, users, discussion, en
     'objectType': CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_DISCUSSION,
     'user': reply.user_id,
     'metadata': {
-      'entryId': entry.id
+      'entryId': reply.id
     }
   };
   getOrCreateActivity(ctx, activities, users, activity, function(err) {
@@ -934,7 +934,7 @@ var handleDiscussionEntryReply = function(ctx, activities, users, discussion, en
       'user': entry.user_id,
       'actor': reply.user_id,
       'metadata': {
-        'entryId': entry.id
+        'entryId': reply.id
       }
     };
     return getOrCreateActivity(ctx, activities, users, activity, callback);


### PR DESCRIPTION
A fix for the reopened https://jira.ets.berkeley.edu/jira/browse/COL-473.