### PR TITLE
COL-537 Fix activity-tracking logic for threaded discussions

### DIFF
--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -906,8 +906,19 @@ var createDiscussionEntryActivity = function(ctx, activities, users, discussion,
  * @api private
  */
 var handleDiscussionEntryReply = function(ctx, activities, users, discussion, entry, reply, callback) {
-  // Users replying to their own entry don't earn points
-  if (entry.user_id === reply.user_id) {
+  // Find parent entry or reply
+  var parent = (reply.parent_id === entry.id) ? entry : _.find(entry.recent_replies, {'id': reply.parent_id});
+  if (!parent) {
+    log.error({
+      'replyId': reply.id,
+      'discussionId': discussion.id,
+      'entry': entry,
+    }, 'Could not find parent for a discussion reply');
+    return callback();
+  }
+
+  // Users replying to their own entry or reply don't generate points
+  if (reply.user_id === parent.user_id) {
     return callback();
   }
 
@@ -931,7 +942,7 @@ var handleDiscussionEntryReply = function(ctx, activities, users, discussion, en
       'type': 'get_discussion_entry_reply',
       'objectId': discussion.id,
       'objectType': CollabosphereConstants.ACTIVITY.OBJECT_TYPES.CANVAS_DISCUSSION,
-      'user': entry.user_id,
+      'user': parent.user_id,
       'actor': reply.user_id,
       'metadata': {
         'entryId': reply.id

--- a/node_modules/col-canvas/tests/model.js
+++ b/node_modules/col-canvas/tests/model.js
@@ -283,7 +283,13 @@ var CanvasDiscussion = module.exports.CanvasDiscussion = function(user, entries,
       data.discussion_subentry_count++;
 
       if (entry.parent_id) {
-        var parentEntry = _.find(entries, {'id': entry.parent_id});
+        var parentEntry = _.find(entries, function(candidateEntry) {
+          if (candidateEntry.id === entry.parent_id) {
+            return true;
+          } else if (_.find(candidateEntry.recent_replies, {'id': entry.parent_id})) {
+            return true;
+          }
+        });
         if (parentEntry) {
           parentEntry.recent_replies.push(entry);
         }

--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -1230,7 +1230,34 @@ describe('Canvas poller', function() {
                                         // User 2 should get additional points for the second entry.
                                         UsersTestUtil.assertGetLeaderboard(client1, course, 3, false, function(users) {
                                           assert.strictEqual(getUserByName(users, user2.fullName).points, (entryPoints * 2) + entryGetReplyPoints);
-                                          return callback();
+   
+                                          // User 2 replies to User 3's reply on User 2's entry
+                                          var user3Reply = discussion.getEntries()[0].recent_replies[0];
+                                          discussion.addEntry(new CanvasDiscussionEntry(user2, user3Reply.id));
+                                          CanvasTestsUtil.mockPollingRequests(dbCourse, mockedUsers, [], [discussion]);
+                                          CanvasPoller.handleCourse(dbCourse, null, function(err) {
+                                            assert.ok(!err);
+
+                                            // User 2 and User 3 should get additional points
+                                            UsersTestUtil.assertGetLeaderboard(client1, course, 3, false, function(users) {
+                                              assert.strictEqual(getUserByName(users, user2.fullName).points, (entryPoints * 3) + entryGetReplyPoints);
+                                              assert.strictEqual(getUserByName(users, user3.fullName).points, entryPoints + entryGetReplyPoints);
+
+                                              // User 3 replies to User 3's reply on User 2's entry
+                                              discussion.addEntry(new CanvasDiscussionEntry(user3, user3Reply.id));
+                                              CanvasTestsUtil.mockPollingRequests(dbCourse, mockedUsers, [], [discussion]);
+                                              CanvasPoller.handleCourse(dbCourse, null, function(err) {
+                                                assert.ok(!err);
+
+                                                // No one should get additional points
+                                                UsersTestUtil.assertGetLeaderboard(client1, course, 3, false, function(users) {
+                                                  assert.strictEqual(getUserByName(users, user2.fullName).points, (entryPoints * 3) + entryGetReplyPoints);
+                                                  assert.strictEqual(getUserByName(users, user3.fullName).points, entryPoints + entryGetReplyPoints);
+                                                  return callback();
+                                                });
+                                              });
+                                            });
+                                          });
                                         });
                                       });
                                     });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-537

The criterion for "who are you replying to?" should not be "who originally started the thread?"; it should be "who are you replying to?".