### PR TITLE
COL-538, we need not 'get latest code' when deploying to network

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,9 +11,6 @@ git clone git://github.com/ets-berkeley-edu/collabosphere.git
 
 cd ~/collabosphere
 
-# Get the latest code
-git pull
-
 # Deploy specified branch or tag and then start the server:
 ./deploy/deploy.sh [-r remote] [-b branch] [-t tag]
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-538

I noticed this extraneous instruction when reviewing release-instructions doc.