### PR TITLE
COL-541 Lower log level on discussion replies with missing parents

### DIFF
--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -909,10 +909,13 @@ var handleDiscussionEntryReply = function(ctx, activities, users, discussion, en
   // Find parent entry or reply
   var parent = (reply.parent_id === entry.id) ? entry : _.find(entry.recent_replies, {'id': reply.parent_id});
   if (!parent) {
-    log.error({
-      'replyId': reply.id,
+    log.debug({
       'discussionId': discussion.id,
-      'entry': entry,
+      'entryId': entry.id,
+      'reply': {
+        'id': reply.id,
+        'parentId': reply.parent_id
+      }
     }, 'Could not find parent for a discussion reply');
     return callback();
   }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-541

Since orphaned replies will call this every time the poller runs, a big grumpy error log is too noisy. 