### PR TITLE
COL-516, roles are course-specific; full URNs in LTI spec describe context

### DIFF
--- a/node_modules/col-canvas/lib/poller.js
+++ b/node_modules/col-canvas/lib/poller.js
@@ -317,7 +317,7 @@ var handleUser = function(ctx, users, canvasUser, callback) {
 
     // Map anything with a Canvas `Teacher` enrollment role to the `Instructor` LTI role
     if (_.includes(CollabosphereConstants.TEACHER_ENROLLMENTS, enrollment.role)) {
-      courseRole = 'Instructor';
+      courseRole = 'urn:lti:role:ims/lis/Instructor';
     }
   }
 

--- a/node_modules/col-canvas/tests/test-poller.js
+++ b/node_modules/col-canvas/tests/test-poller.js
@@ -233,7 +233,7 @@ describe('Canvas poller', function() {
 
               var teacher = getUserByName(users, 'Active teacher');
               UsersTestUtil.assertUser(teacher, {'expectEmail': true});
-              assert.strictEqual(teacher.canvas_course_role, 'Instructor');
+              assert.strictEqual(teacher.canvas_course_role, 'urn:lti:role:ims/lis/Instructor');
               assert.strictEqual(teacher.canvas_enrollment_state, 'active');
 
               // Verify a subsequent run won't create another user record
@@ -1230,7 +1230,7 @@ describe('Canvas poller', function() {
                                         // User 2 should get additional points for the second entry.
                                         UsersTestUtil.assertGetLeaderboard(client1, course, 3, false, function(users) {
                                           assert.strictEqual(getUserByName(users, user2.fullName).points, (entryPoints * 2) + entryGetReplyPoints);
-   
+
                                           // User 2 replies to User 3's reply on User 2's entry
                                           var user3Reply = discussion.getEntries()[0].recent_replies[0];
                                           discussion.addEntry(new CanvasDiscussionEntry(user2, user3Reply.id));

--- a/node_modules/col-core/lib/constants.js
+++ b/node_modules/col-core/lib/constants.js
@@ -34,9 +34,20 @@ var Constants = module.exports = {
       'WHITEBOARD': 'whiteboard'
     }
   },
-  'ADMIN_ROLES': ['urn:lti:instrole:ims/lis/Administrator'],
-  'TEACHER_ROLES': ['ContentDeveloper', 'Instructor', 'urn:lti:role:ims/lis/TeachingAssistant'],
-  'TEACHER_ENROLLMENTS': ['Adv Designer', 'DesignerEnrollment', 'TaEnrollment', 'TeacherEnrollment'],
+  'ADMIN_ROLES': [
+    'urn:lti:instrole:ims/lis/Administrator'
+  ],
+  'TEACHER_ROLES': [
+    'urn:lti:role:ims/lis/ContentDeveloper',
+    'urn:lti:role:ims/lis/Instructor',
+    'urn:lti:role:ims/lis/TeachingAssistant'
+  ],
+  'TEACHER_ENROLLMENTS': [
+    'Adv Designer',
+    'DesignerEnrollment',
+    'TaEnrollment',
+    'TeacherEnrollment'
+  ],
   'ASSET': {
     'ASSET_TYPES': ['file', 'link', 'whiteboard', 'thought']
   },

--- a/node_modules/col-tests/lib/util.js
+++ b/node_modules/col-tests/lib/util.js
@@ -194,7 +194,7 @@ var generateCanvasAdmin = module.exports.generateCanvasAdmin = function(canvas, 
  * @return {User}                                     An object that contains the information about the user
  */
 var generateInstructor = module.exports.generateInstructor = function(canvas, id, givenName, familyName, loginId, userImage) {
-  return generateUser(canvas, id, 'Instructor', givenName, familyName, loginId, userImage);
+  return generateUser(canvas, id, 'urn:lti:role:ims/lis/Instructor', givenName, familyName, loginId, userImage);
 };
 
 /**

--- a/node_modules/col-users/tests/test-users.js
+++ b/node_modules/col-users/tests/test-users.js
@@ -51,12 +51,12 @@ describe('Users', function() {
      */
     it('correctly identifies admins', function(callback) {
       // Verify that all admin roles are correctly returned as admins
-      var admin1 = TestsUtil.generateUser(null, null, 'Instructor');
+      var admin1 = TestsUtil.generateUser(null, null, 'urn:lti:role:ims/lis/Instructor');
       TestsUtil.getAssetLibraryClient(null, null, admin1, function(client, course, user) {
         UsersTestUtil.assertGetMe(client, course, null, function(me) {
           assert.strictEqual(me.is_admin, true);
 
-          var admin2 = TestsUtil.generateUser(null, null, 'ContentDeveloper');
+          var admin2 = TestsUtil.generateUser(null, null, 'urn:lti:role:ims/lis/ContentDeveloper');
           TestsUtil.getAssetLibraryClient(null, null, admin2, function(client, course, user) {
             UsersTestUtil.assertGetMe(client, course, null, function(me) {
               assert.strictEqual(me.is_admin, true);
@@ -71,7 +71,7 @@ describe('Users', function() {
                     UsersTestUtil.assertGetMe(client, course, null, function(me) {
                       assert.strictEqual(me.is_admin, true);
 
-                      var admin5 = TestsUtil.generateUser(null, null, 'Instructor,FooBar');
+                      var admin5 = TestsUtil.generateUser(null, null, 'urn:lti:role:ims/lis/Instructor,FooBar');
                       TestsUtil.getAssetLibraryClient(null, null, admin5, function(client, course, user) {
                         UsersTestUtil.assertGetMe(client, course, null, function(me) {
                           assert.strictEqual(me.is_admin, true);

--- a/node_modules/col-whiteboards/tests/test-whiteboards.js
+++ b/node_modules/col-whiteboards/tests/test-whiteboards.js
@@ -71,13 +71,13 @@ describe('Whiteboards', function() {
             TestsUtil.getAssetLibraryClient(null, course, null, function(regularClientB, course, regularUserB) {
               UsersTestUtil.assertGetMe(regularClientB, course, null, function(regularMeB) {
                 // Generate a course instructor in the same course
-                var instructor = TestsUtil.generateUser(null, null, 'Instructor');
+                var instructor = TestsUtil.generateUser(null, null, 'urn:lti:role:ims/lis/Instructor');
                 TestsUtil.getAssetLibraryClient(null, course, instructor, function(instructorClient, course, instructor) {
                   // Generate a regular user in a different course
                   TestsUtil.getAssetLibraryClient(null, null, null, function(regularOtherCourseClient, otherCourse, regularOtherCourseUser) {
                     UsersTestUtil.assertGetMe(regularOtherCourseClient, otherCourse, null, function(regularOtherCourseMe) {
                       // Generate a course instructor in a different course
-                      var instructorOtherCourse = TestsUtil.generateUser(null, null, 'Instructor');
+                      var instructorOtherCourse = TestsUtil.generateUser(null, null, 'urn:lti:role:ims/lis/Instructor');
                       TestsUtil.getAssetLibraryClient(null, otherCourse, instructorOtherCourse, function(instructorOtherCourseClient, otherCourse, instructorOtherCourse) {
 
                         var users = {
@@ -342,7 +342,7 @@ describe('Whiteboards', function() {
               // First user sees no other users online
               WhiteboardsTestUtil.assertGetWhiteboards(users.regularA.client, course, null, null, null, 1, function(whiteboards) {
                 WhiteboardsTestUtil.assertWhiteboard(whiteboards.results[0], {'expectedOnlineCount': 0});
-                  
+
                 return callback();
               });
             });
@@ -502,7 +502,7 @@ describe('Whiteboards', function() {
             // Second user creates a private whiteboard
             WhiteboardsTestUtil.assertCreateWhiteboard(users.regularB.client, course, 'Private Davis board', [users.regularB.me.id], function(privateDavisBoard) {
               whiteboardsB.push(privateDavisBoard);
-            
+
               // Each user creates one whiteboard shared with the other
               WhiteboardsTestUtil.assertCreateWhiteboard(users.regularA.client, course, 'Shared Berkeley board', [users.regularA.me.id, users.regularB.me.id], function(sharedBerkeleyBoard) {
                 WhiteboardsTestUtil.assertCreateWhiteboard(users.regularB.client, course, 'Shared Davis board', [users.regularA.me.id, users.regularB.me.id], function(sharedDavisBoard) {
@@ -521,7 +521,7 @@ describe('Whiteboards', function() {
                               // An administrator should be able to see all whiteboards associated with a user
                               verifySearch(users.instructor.client, course, {'user': users.regularA.me.id}, whiteboardsA.concat(whiteboardsShared), function() {
                                 verifySearch(users.instructor.client, course, {'user': users.regularB.me.id}, whiteboardsB.concat(whiteboardsShared), function() {
-                                  
+
                                   // An administrator should be able to see all whiteboards with titles matching a keyword
                                   verifySearch(users.instructor.client, course, {'keywords': 'Berkeley'}, [privateBerkeleyBoard, sharedBerkeleyBoard], function() {
                                     verifySearch(users.instructor.client, course, {'keywords': 'Davis'}, [privateDavisBoard, sharedDavisBoard], function() {
@@ -531,7 +531,7 @@ describe('Whiteboards', function() {
                                         verifySearch(users.instructor.client, course, {'user': users.regularA.me.id, 'keywords': 'Davis'}, [sharedDavisBoard], function() {
                                           verifySearch(users.instructor.client, course, {'user': users.regularB.me.id, 'keywords': 'Berkeley'}, [sharedBerkeleyBoard], function() {
                                             verifySearch(users.instructor.client, course, {'user': users.regularB.me.id, 'keywords': 'Davis'}, [privateDavisBoard, sharedDavisBoard], function() {
-                            
+
                                               // Keywords matching nothing should return empty
                                               verifySearch(users.regularA.client, course, {'keywords': 'This matches nothing'}, [], function() {
                                                 // Keywords matching nothing for a regular user should return empty
@@ -541,7 +541,7 @@ describe('Whiteboards', function() {
 
                                                     return callback();
                                                   });
-                                                });   
+                                                });
                                               });
                                             });
                                           });

--- a/scripts/20161121-col516/update_canvas_course_role_values.sql
+++ b/scripts/20161121-col516/update_canvas_course_role_values.sql
@@ -1,0 +1,4 @@
+-- Roles are recorded using full URN as seen in https://www.imsglobal.org/specs/ltiv1p0/implementation-guide.
+
+update users set canvas_course_role='urn:lti:role:ims/lis/Instructor' where canvas_course_role='Instructor';
+update users set canvas_course_role='urn:lti:role:ims/lis/ContentDeveloper' where canvas_course_role='ContentDeveloper';


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-516

Roles are recorded using full URN as seen in [LTI implementation-guide](https://www.imsglobal.org/specs/ltiv1p0/implementation-guide). Using namespaces avoids confusion with, for example, the `Instructor` role which is applicable in two contexts: institutional and course-level.

SQL script to migrate user data is included.