### PR TITLE
COL-497 Default created_at and updated_at values in Canvas table

### DIFF
--- a/scripts/20161121-col497/default_canvas_timestamp_values.sql
+++ b/scripts/20161121-col497/default_canvas_timestamp_values.sql
@@ -1,0 +1,16 @@
+-- Default created_at and updated_at for Canvas table to current time at creation.
+
+ALTER TABLE canvas ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE canvas ALTER COLUMN updated_at SET DEFAULT now();
+
+-- Update updated_at for Canvas table to current time on update.
+
+CREATE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;	
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_canvas_updated_at BEFORE UPDATE ON canvas FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-497

See http://www.revsys.com/blog/2006/aug/04/automatically-updating-a-timestamp-column-in-postgresql/